### PR TITLE
Fix typos in a various docs

### DIFF
--- a/source/docs/docker-storage-recommendation.md
+++ b/source/docs/docker-storage-recommendation.md
@@ -2,17 +2,17 @@
 
 ## Introduction
  
-The Atomic Controler is a minimal Linux distribution specifically purposed for hosting lxc/Docker containers. Atomic Controller is distributed on a 8.5Gb image to keep it's footprint small. That amount of storage doesn't support building and storing lots of Docker images.  It is expected practice that external storage of sufficient size will be attached to the Atomic Controler host  in order to provide enough space to build and storage Docker images . Docker depends on `/usr/lib/docker` as the default directory where all docker related files, including the images, are stored. If you use the default `/var/lib/docker` provided in the Atomic Controler image then it will fill up fast and soon Docker and the host will become unusable.
+The Atomic Controller is a minimal Linux distribution specifically purposed for hosting lxc/Docker containers. Atomic Controller is distributed on a 8.5Gb image to keep it's footprint small. That amount of storage doesn't support building and storing lots of Docker images.  It is expected practice that external storage of sufficient size will be attached to the Atomic Controller host in order to provide enough space to build and store Docker images . Docker depends on `/var/lib/docker` as the default directory where all docker related files, including the images, are stored. If you use the default `/var/lib/docker` provided in the Atomic Controller image then it will fill up fast and soon Docker and the host will become unusable.
  
 This document/section provides instructions on the recommended steps on how to use an attached volume with your Atomic Controller host so that you can build and store lots of Docker images.
  
 ## Preliminary Steps
 
-Before setting up the `/var/lib/docker` directory to use the external volume it is assumed you have attached that volume to your host. Here is an example of setting up a 30Gb external volume to a Atomic Controler virtual machine.
+Before setting up the `/var/lib/docker` directory to use the external volume it is assumed you have attached that volume to your host. Here is an example of setting up a 30Gb external volume to a Atomic Controller virtual machine.
  
-    # lvcreate --size 30GB --name extra-disk-for-atomic-controler
+    # lvcreate --size 30GB --name extra-disk-for-atomic-controller
  
-Attach the volume to the Atomic Controler host virtual machine in virt-manager. Reboot the virtual machine. On the Atomic Controler host, ensure the device is available.
+Attach the volume to the Atomic Controller host virtual machine in virt-manager. Reboot the virtual machine. On the Atomic Controller host, ensure the device is available.
  
     # fdisk -l
  
@@ -20,13 +20,13 @@ Create a partition using the new device discovered using the above command. E.g.
  
     # fdisk /dev/sdb1
  
-Now create a file system on the new partition, or start using lvm here. The preferred file systems types for Atomic Controler are ext4 and xfs.
+Now create a file system on the new partition, or start using lvm here. The preferred file systems types for Atomic Controller are ext4 and xfs.
  
     # mkfs.xfs /dev/sdb1
  
 ## Setting Up /var/lib/docker
 
-Before setting up the external volume consider if there are already important images or containers already in use on this host.  It is unlikely due to the size of the image and it is preferred to do these recommended steps before building or pulling down images. i.e. it is not recommended to use Atomic Controler before attaching an external volume. But if there is important information in `/usr/lib/docker` then it is best to copy this to a backup directory now.
+Before setting up the external volume consider if there are already important images or containers already in use on this host.  It is unlikely due to the size of the image and it is preferred to do these recommended steps before building or pulling down images. i.e. it is not recommended to use Atomic Controller before attaching an external volume. But if there is important information in `/var/lib/docker` then it is best to copy this to a backup directory now.
 
     # cp -r  /var/lib/docker  /my-backupd-dir
 

--- a/source/docs/quickstart.md
+++ b/source/docs/quickstart.md
@@ -14,7 +14,7 @@ Here's how to get started with Atomic on your machine using virt-manager on Linu
 
 1. Download the virt-manager image.
 
-2. Run `xd -d [filename]` to uncompress the downloaded image.
+2. Run `xz -d [filename]` to uncompress the downloaded image.
 
 3. Start virt-manager.
 


### PR DESCRIPTION
- Change 'Controler' to 'Controller'
- 'build and storage' -> 'build and store'
- /usr/lib/docker -> /var/lib/docker
- xd -> xz
