### PR TITLE
Add RSS link in <head> for automated feed discovery

### DIFF
--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -29,6 +29,9 @@
     -# https://support.google.com/plus/answer/1713826?hl=en&ref_topic=3293784
     %link(rel="publisher" href="https://plus.google.com/108727025270662383247")
 
+    -# RSS link for automatic feed discovery tools
+    %link(rel="alternate" type="application/atom+xml" title="Blog Articles" href="/blog/feed.xml")
+
     -# App Icons
     %link(rel="shortcut icon" href="/images/favicon.ico")
     %link(rel="apple-touch-icon-precomposed" href="/images/apple-touch-icon-precomposed.png")


### PR DESCRIPTION
As an interested reader, I wanted an easier way to keep up with these blog articles and saw that you were using middleman-blog already.

This change allows certain browsers, feed readers, etc. to automatically discover the article feed.

(Whoops, I wrote RSS the whole time but it's technically an _Atom_ feed...)
