### PR TITLE
Cockpit no longer needs selinux to be disabled

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -102,7 +102,6 @@ title: Get Started with Project Atomic
 
     %pre
       :preserve
-        # setenforce 0 
         # systemctl enable cockpit.socket
         # systemctl start cockpit.socket
         # visit http://&lt;ipaddress&gt;:21064 in a browser


### PR DESCRIPTION
The selinux policy in atomic has been updated so that this is no
longer necessary.
