### PR TITLE
Remove the security warning about cockpit

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -113,8 +113,7 @@ title: Get Started with Project Atomic
     %p
       The snapshot of Cockpit included in Atomic is a preview - do
       not use in production environments.  Cockpit is under rapid
-      development, with work on security hardening and reliability
-      ongoing.
+      development.
 
     %p 
       %a( href="http://cockpit-project.org" ) &raquo; Visit cockpit-project.org...


### PR DESCRIPTION
Now that 0.8 is released and most of the code runs unprivileged
we're more comfortable with the security of Cockpit.
