### PR TITLE
Do not pull pry by default as this is not building on latest 2.0.0 ruby ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.0.0-p247
+- 2.0.0
 install:
 - sudo apt-get update -qq
 - sudo apt-get install -y ruby-dev git make gcc

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,6 @@ gem "middleman", "~>3.2"
 # Live-reloading plugin
 gem "middleman-livereload"
 
-# Debugger / REPL alternative to irb
-gem 'pry'
-gem 'pry-debugger'
-gem 'pry-stack_explorer'
-
 # Cross-templating language block fix for Ruby 1.8
 platforms :mri_18 do
   gem "ruby18_source_location"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,30 +7,19 @@ GEM
     addressable (2.3.5)
     asciidoctor (0.1.4)
     atomic (1.1.16)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bootstrap-sass (3.0.0.0)
       sass (~> 3.2)
     builder (3.2.2)
     chunky_png (1.3.0)
-    coderay (1.1.0)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
     coffee-script-source (1.7.0)
-    columnize (0.3.6)
     commonjs (0.2.7)
     compass (0.12.3)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
       sass (= 3.2.14)
-    debug_inspector (0.0.2)
-    debugger (1.6.6)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     docile (1.1.3)
     em-websocket (0.5.0)
       eventmachine (>= 0.12.9)
@@ -60,7 +49,6 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
-    method_source (0.8.2)
     middleman (3.2.2)
       coffee-script (~> 2.2.0)
       compass (>= 0.12.2)
@@ -115,16 +103,6 @@ GEM
       mini_portile (~> 0.5.0)
     oj (2.6.0)
     open-uri-cached (0.0.5)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-    pry-debugger (0.2.2)
-      debugger (~> 1.3)
-      pry (~> 0.9.10)
-    pry-stack_explorer (0.4.9.1)
-      binding_of_caller (>= 0.7)
-      pry (>= 0.9.11)
     ptools (1.2.4)
     rack (1.5.2)
     rack-livereload (0.3.15)
@@ -142,7 +120,6 @@ GEM
     rouge (1.3.3)
     ruby18_source_location (0.2)
     sass (3.2.14)
-    slop (3.5.0)
     sprockets (2.12.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -189,9 +166,6 @@ DEPENDENCIES
   nokogiri
   oj
   open-uri-cached
-  pry
-  pry-debugger
-  pry-stack_explorer
   redcarpet
   ruby18_source_location
   therubyracer


### PR DESCRIPTION
...in travis

Since that's not needed to build, anyone wanting it can install it by himself
