### PR TITLE
Typo in blog

### DIFF
--- a/source/blog/2014-10-17-getting-started-with-cloud-init.md
+++ b/source/blog/2014-10-17-getting-started-with-cloud-init.md
@@ -31,7 +31,7 @@ local-hostname: atomic-host-001
 
 One important note about making iterative changes during testing.  If you change the user-data or meta-data files and rebuild the ISO, you will need to update the instance-id.  This is how `cloud-init` knows if this is the first boot of a specific instantiated host.
 
-For our user-data file, I'm going to set a password and inject a ssh key for the default user 'fedora'.  I don't want to use my normal key here, so I'll build one for this example.  I've also set ssh up to accept a password.  You can skip that if you want key online authentication.  
+For our user-data file, I'm going to set a password and inject a ssh key for the default user 'fedora'.  I don't want to use my normal key here, so I'll build one for this example.  I've also set ssh up to accept a password.  You can skip that if you want key only authentication.  
 
 ```
 $ ssh-keygen -f atomic_rsa


### PR DESCRIPTION
Figures I didn't catch this until after publication, 'key online authentication' doesn't make sense.

This is also showing up as 2 changes, one doesn't appear to be an actual change.  Not sure why that's there.  I can resubmit if something needs to be cleaned up first.
