### PR TITLE
Updating quickstart to fix copy/paste issue with markdown rendering

### DIFF
--- a/source/docs/quickstart.md
+++ b/source/docs/quickstart.md
@@ -58,44 +58,42 @@ Here's how to get started with Atomic on your machine using VirtualBox on Window
 
 You will need to create a metadata ISO to supply data through [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) when your host boots. 
 
-1. Create a ```meta-data``` file with your desired hostname and any instance-id.
+1. Create a `meta-data` file with your desired hostname and any instance-id.
 
-  ```
-  $ cat meta-data
-  instance-id: id-local01
-  local-hostname: samplehost.example.org
-  ```
-2. Create a ```user-data``` file. The #cloud-config directive at the beginning of the file is mandatory.
-  ```
-  $ cat user-data
-  #cloud-config
-  password: mypassword 
-  ssh_pwauth: True
-  chpasswd: { expire: False }
-  
-  ssh_authorized_keys: 
-    - ssh-rsa ... foo@bar.baz (insert ~/.ssh/id_rsa.pub here)
-  ```
+        $ cat meta-data
+        instance-id: id-local01
+        local-hostname: samplehost.example.org
+
+2. Create a `user-data` file. The #cloud-config directive at the beginning of the file is mandatory.
+
+        $ cat user-data
+        #cloud-config
+        password: mypassword 
+        ssh_pwauth: True
+        chpasswd: { expire: False }
+            
+        ssh_authorized_keys: 
+          - ssh-rsa ... foo@bar.baz (insert ~/.ssh/id_rsa.pub here)
+
 3. After creating the `user-data` and `meta-data` files, generate an ISO. Make sure the user running libvirt has the proper permissions to read the generated image.
 
-  ```$ genisoimage -output init.iso -volid cidata -joliet -rock user-data meta-data```
+        $ genisoimage -output init.iso -volid cidata -joliet -rock user-data meta-data
 
 #### virt-manager
 
 1. In the virt-manager GUI, click to open your Atomic machine. Then on the top bar click *View > Details*
 2. Click on *Add Hardware* on the bottom left corner.
-3. Choose *Storage*, and *Select managed or other existing storage*. Browse and select the `init.iso` image you created. Click on *Finish* to create and attach this storage.
-4. Go to *Boot Options* and check the box next to the name of the recently created device, under the *Boot device order* menu. This will make your system boots using the cloud-init ISO.
-5. You should be able to boot your machine and use the password or SSH keys specified in your `user-data` file.
+3. Choose *Storage*, and *Select managed or other existing storage*. Browse and select the `init.iso` image you created. Change the *Device type* to CDROM device.  Click on *Finish* to create and attach this storage.
 
 #### VirtualBox
 
 1. In the VirtualBox GUI, click *Settings* for you Atomic virtual machine.
 2. On the *Storage* tab, for the IDE Controller, *Add CD/DVD Device*.
 3. Select *Choose Disk*, and select the `init.iso` you created.
-4. Boot your machine with the disk attached and cloud-init will populate your user information with the password you provided. **For a Fedora image, the user is `fedora`, for CentOS the user is `centos`.**
 
-Now that you've booted and logged in to your machine, you can update the system software with `$ sudo rpm-ostree upgrade` to pull in any updates.
+Boot the virtual machine with the disk attached and cloud-init will populate the default user information with the password or SSH keys you provided in the `user-data` file. **For a Fedora image, the default user is `fedora`, for CentOS the default user is `centos`.**
+
+Once you've booted and logged in to your Atomic host, you can update the system software with `$ sudo rpm-ostree upgrade` to pull in any updates.
 
 ## Readying More Space For Containers
 


### PR DESCRIPTION
Helping troubleshoot an issue in IRC, it was noted by @larsks that copy and pasting from the website resulted in leading spaces in the text for the user-data and meta-data files.  This was causing issues with cloud-init not picking up the contents of the file.  The issue stemmed from using a code span indicator instead of indents to wrap the block.    As an aside, this is a Middleman render issue since github renders the original and this PR the same way, with no leading spaces.

For code blocks in lists, the indent becomes dependent on list sublevel, so the right indent for code block is 4 x the indent level.  So for this case, 8 spaces.  There were some ways to combine span indicators and indent, but I didn't find one that resulted in no leading spaces when copying from the site.

I also cleaned up the device attachment process for virt-manager of init.iso, changed the device type to cdrom so there wasn't a need to change the boot order.  cloud-init will locate the ISO automatically as an attached cdrom.  I merged some duplicated info in the virt-manager vs VirtualBox sections.