### PR TITLE
Updated storage document for devicemapper thin pool

### DIFF
--- a/source/docs/docker-storage-recommendation.md
+++ b/source/docs/docker-storage-recommendation.md
@@ -2,79 +2,130 @@
 
 ## Introduction
  
-The Atomic Host is a minimal Linux distribution specifically purposed for hosting lxc/Docker containers. Atomic Host is distributed on a 8.5Gb image to keep it's footprint small. That amount of storage doesn't support building and storing lots of Docker images.  It is expected practice that external storage of sufficient size will be attached to the Atomic Host host in order to provide enough space to build and store Docker images . Docker depends on `/var/lib/docker` as the default directory where all docker related files, including the images, are stored. If you use the default `/var/lib/docker` provided in the Atomic Host image then it will fill up fast and soon Docker and the host will become unusable.
- 
-This document/section provides instructions on the recommended steps on how to use an attached volume with your Atomic Host host so that you can build and store lots of Docker images.
- 
-## Preliminary Steps
+The Atomic host is a minimal distribution and as such is distributed on a 6Gb image to keep the footprint small. However, that amount of storage doesn't support building and storing lots of Docker images.  It is an expected practice that external storage of sufficient size will be attached to the Atomic Host host in order to provide enough space to build and store Docker images. 
 
-Before setting up the `/var/lib/docker` directory to use the external volume it is assumed you have attached that volume to your host. Here is an example of setting up a 30Gb external volume to a Atomic Host virtual machine.
+Docker uses `/var/lib/docker` as the default directory where all docker related files, including the images, are stored.  Atomic hosts however use direct LVM volumes via the devicemapper backend to store Docker images and metadata `/dev/atomicos/docker-data` and `/dev/atomicos/docker-meta`.  Adding storage to an Atomic hosts therefore requires a different procedure to grow the LVM volume than adding more storage to a device mounted at `/var/lib/docker`.   
  
-    # lvcreate --size 30GB --name extra-disk-for-atomic-controller
+This document provides instructions for using an attached device with your Atomic host so that you can build and store lots of Docker images.  The basic procedure is the same as extending any other LVM volume.  Add the new device to the host, create a physical volume using the new device, add the physical volume to the volume group, and then extend the LVM volumes.  Since we are directly accessing the thin pool within docker, we won't need to create or extend a filesystem or mount the LVM volumes.
  
-Attach the volume to the Atomic Host host virtual machine in virt-manager. Reboot the virtual machine. On the Atomic Host host, ensure the device is available.
- 
-    # fdisk -l
- 
-Create a partition using the new device discovered using the above command. E.g. if `/dev/sdb1` is the device name:
- 
-    # fdisk /dev/sdb1
- 
-Now create a file system on the new partition, or start using lvm here. The preferred file systems types for Atomic Host are ext4 and xfs.
- 
-    # mkfs.xfs /dev/sdb1
- 
-## Setting Up /var/lib/docker
+## Using the `docker-storage-setup` LVM helper
+_In this example, we'll be using a virt-manager installed Atomic host_.  
+Create a new VirtIO drive for use by the virtual machine and attach the volume to the Atomic host virtual machine in virt-manager.  On the Atomic host, ensure the device is available.  You may need to reboot the virtual machine.  Make sure no partitions are listed on the device, as we'll be adding this as a physical volume in LVM and get the appropriate device name.  
 
-Before setting up the external volume consider if there are already important images or containers already in use on this host.  It is unlikely due to the size of the image and it is preferred to do these recommended steps before building or pulling down images. i.e. it is not recommended to use Atomic Host before attaching an external volume. But if there is important information in `/var/lib/docker` then it is best to move this to a temporary location until it can be placed on the external volume.
-
-    # mv /var/lib/docker  /my-backupd-dir
-
-Stop the docker service.
-
-    # systemctl stop docker
-
-Now, getting back to the new device, get the UUID from the device.
+In the example, you can see a new 5GiB volume available at `/dev/vdb`.  This is the disk we'll add to the available pool.
  
-    # blkid /dev/sdb1
- 
-Then add that to the `/etc/fstab` in the format:
+    [fedora@atomic-host-001 ~]$ sudo fdisk -l
 
-    UUID=<UUID-from-blkid> /var/lib/docker <file system type> defaults 1 1
- 
-For our xfs example it looks something like like:
- 
-    UUID=be840c0d-91f8-41fa-bb40-82e1c4e2e985 /var/lib/docker xfs defaults 1 1
- 
+    Disk /dev/vda: 6 GiB, 6442450944 bytes, 12582912 sectors
+    Units: sectors of 1 * 512 = 512 bytes
+    Sector size (logical/physical): 512 bytes / 512 bytes
+    I/O size (minimum/optimal): 512 bytes / 512 bytes
+    Disklabel type: dos
+    Disk identifier: 0x0e409ce2
 
-## Start Using The New Volume With Docker
+    Device     Boot  Start      End  Sectors  Size Id Type
+    /dev/vda1  *      2048   411647   409600  200M 83 Linux
+    /dev/vda2       411648 12582911 12171264  5.8G 8e Linux LVM
 
-The volume is ready to be mounted and used by Docker. Mount the device:
+    Disk /dev/vdb: 5 GiB, 5368709120 bytes, 10485760 sectors
+    Units: sectors of 1 * 512 = 512 bytes
+    Sector size (logical/physical): 512 bytes / 512 bytes
+    I/O size (minimum/optimal): 512 bytes / 512 bytes
+    Disklabel type: dos
+    Disk identifier: 0x00000000
 
-    # mount -a
- 
-If you did move any data from `/var/lib/docker` then now is a good time to move it to then new volume. Then restart the docker service:
- 
-    # systemctl start docker
+## Setting Up /etc/sysconfig/docker-storage-setup
 
-If the provided `/var/lib/docker` was not moved as descrbed above then it is easy to check if everything worked.  After the docker service has started you should see the following files in the `/var/lib/docker` with ls :
+Atomic hosts are delivered with a helper script to configure the direct LVM storage, `docker-storage-setup`.  The script reads from configuration options in `/etc/sysconfig/docker-storage-setup`.
 
-    containers  devicemapper  execdriver  graph  init  linkgraph.db  
-    lxc-start-unconfined  repositories-devicemapper  vfs  volumes
+We'll set up a very basic configuration file to add the new device to the docker data storage pool.  The two options we'll deal with is `DEVS` and `VG`.  
+The `DEVS` option is a space separated list of the devices you want to add to the pool.  The `docker-storage-setup` script will automatically calculate the required amount of meta-data space from the overall size of the volume group, grow that volume, and then grow the data volume with the remaining space.
 
-If you moved the original contents of `/var/lib/docker` ensure this directory contains the data you expect.
-Another test is to build an image. Here is a simple example `Dockerfile`:
+The `VG` option allows you to control the volume group used for docker storage.  By default, Atomic uses the same volume group as the root device.  This means that you can set or change the root volume size with this utility as well.  You can also change the group if you so choose.
+    
+    [fedora@atomic-host-001 ~]$ sudo vi /etc/sysconfig/docker-storage-setup 
+    DEVS="/dev/vdb"
 
-    FROM fedora
-    RUN  yum -y update
+Once you've added the new storage device or devices in the configuration file, you can run the helper script.  If you are adding more than one device at a time, you'll see some of these steps more than once.
 
- 
+    [fedora@atomic-host-001 ~]$ sudo docker-storage-setup 
+    0
+    sfdisk: Checking that no-one is using this disk right now ...
+    sfdisk: OK
+    
+    Disk /dev/vdb: 6241 cylinders, 16 heads, 63 sectors/track
+    sfdisk:  /dev/vdb: unrecognized partition table type
+    Old situation:
+    sfdisk: No partitions found
+    New situation:
+    Units: sectors of 512 bytes, counting from 0
+
+    Device Boot    Start       End   #sectors  Id  System
+    /dev/vdb1          2048   6291455    6289408  8e  Linux LVM
+    /dev/vdb2             0         -          0   0  Empty
+    /dev/vdb3             0         -          0   0  Empty
+    /dev/vdb4             0         -          0   0  Empty
+    sfdisk: Warning: partition 1 does not start at a cylinder boundary
+    sfdisk: Warning: partition 1 does not end at a cylinder boundary
+    sfdisk: Warning: no primary partition is marked bootable (active)
+    This does not matter for LILO, but the DOS MBR will not boot this disk.
+    Successfully wrote the new partition table
+
+    Re-reading the partition table ...
+    
+    sfdisk: If you created or changed a DOS partition, /dev/foo7, say, then use     dd(1)
+    to zero the first 512 bytes:  dd if=/dev/zero of=/dev/foo7 bs=512 count=1
+    (See fdisk(8).)
+    Physical volume "/dev/vdb1" successfully created
+    Volume group "atomicos" successfully extended
+    NOCHANGE: partition 2 could only be grown by -48 [fudge=20480]
+    Physical volume "/dev/vda2" changed
+    1 physical volume(s) resized / 0 physical volume(s) not resized
+    NOCHANGE: partition 1 could only be grown by -16 [fudge=20480]
+    Physical volume "/dev/vdc1" changed
+      1 physical volume(s) resized / 0 physical volume(s) not resized
+    Rounding size to boundary between physical extents: 12.00 MiB
+    Size of logical volume atomicos/docker-meta changed from 8.00 MiB (2 extents) to 12.00 MiB (3 extents).
+    Logical volume docker-meta successfully resized
+    Size of logical volume atomicos/docker-data changed from 3.84 GiB (1494   extents) to 8.83 GiB (2260 extents).
+      Logical volume docker-data successfully resized
+
+You can verify that docker can see the new storage with `docker info`:
+
+    [fedora@atomic-host-001 ~]$ sudo docker info
+    Containers: 0
+    Images: 0
+    Storage Driver: devicemapper
+     Pool Name: docker-253:0-4655104-pool
+     Pool Blocksize: 65.54 kB
+     Backing Filesystem: <unknown>
+     Data file: /dev/atomicos/docker-data
+     Metadata file: /dev/atomicos/docker-meta
+     Data Space Used: 11.8 MB
+     Data Space Total: 4.123 GB
+     Metadata Space Used: 53.25 kB
+     Metadata Space Total: 8.389 MB
+     Udev Sync Supported: true
+     Library Version: 1.02.93 (2015-01-30)
+    Execution Driver: native-0.2
+    Kernel Version: 3.18.7-200.fc21.x86_64
+    Operating System: Fedora 21 (Twenty One)
+    CPUs: 1
+    Total Memory: 1.955 GiB
+    Name: atomic-host-001.localdomain
+    ID: QN7L:2FJ5:CZXS:265G:JVIF:2CB3:35EE:T5KJ:7HXN:OXGG:MEW2:XLC2
+
 ## Looking Forward
 
-In the future it is likely that the recommended mounting for /var/lib/docker will be more granular depending on the performance needs of various sub-directories of `/var/lib/docker`.  Watch this space.
+In order to add a new device using the `docker-storage-setup` script, you will need to make sure that the configuration file only contains references to devices and sizes for this particular run of the tool.  
 
-## Filesystem Considerations
+For example, if you add a new device to host and to the `DEVS` line, the `docker-storage-setup` script will exit as the exisiting device has a partition and physical volume already created.
 
-Docker supports several different filesystem formats. How these work and which one you choose for all or part of your deployment will greatly effect your performance and efficiency.
+    [fedora@atomic-host-002 ~]$ sudo vi /etc/sysconfig/docker-storage-setup
+    DEVS="/dev/vdb /dev/vdc"
 
-For information and recommendations on supported filesystems please see [Supported Filesystems](http://www.projectatomic.io/docs/filesystems/).
+     [fedora@atomic-host-002 ~]$ sudo docker-storage-setup
+    0
+    /dev/vdb has partitions: vdb1
+
+Since Atomic is using the devicemapper backend and direct LVM pools, you can also add new devices manually, as you would with any other LVM configuration.  When adding data storage, you should also calculate the needed space for meta-data, the `docker-storage-setup` helper reserves 0.1% of the size of the volume group as meta-data space.  

--- a/source/docs/docker-storage-recommendation.md
+++ b/source/docs/docker-storage-recommendation.md
@@ -124,7 +124,7 @@ For example, if you add a new device to host and to the `DEVS` line, the `docker
     [fedora@atomic-host-002 ~]$ sudo vi /etc/sysconfig/docker-storage-setup
     DEVS="/dev/vdb /dev/vdc"
 
-     [fedora@atomic-host-002 ~]$ sudo docker-storage-setup
+    [fedora@atomic-host-002 ~]$ sudo docker-storage-setup
     0
     /dev/vdb has partitions: vdb1
 


### PR DESCRIPTION
There have been quite a few questions on the Ask site about extending storage  and the existing "Setting Up Storage" document references the default docker location.  This doc walks through using docker-storage-setup as a user, and talks some about the devicemapper backend and direct LVM pools.  It could be expanded greatly with more info about the backend and thin pools.

It may also not be the best way forward long term, this helper works but doesn't seem like it was intended for admin use so much as system use.  We can add a manual section as well, but I wanted to get something out that reflected the current state and hopefully stemmed a few more questions in the community.