### PR TITLE
add reference to k8s getting started docs on download page

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -108,16 +108,15 @@ title: Get Started with Project Atomic
     %h2 Learn about Kubernetes
 
     %p
-      If you're looking to work with orchestration, you'll want to get started with Kubernetes.
+      If you're looking to work with orchestration, you'll want 
+      to get started with Kubernetes.
 
     %p
-      Scott Collier has been keeping a guide to getting started with Kubernetes on Fedora
-      which shows how to get a simple master and minion setup going. 
-
-    %p 
-      The Getting Started on Fedora guide will walk you through installing the required packages,
-      setting up the configuration, and more. 
-      %a( href="https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/getting-started-guides/fedora/fedora_manual_config.md" ) &raquo; Learn more about Kubernetes...
+      The "Atomic fleet concepts" portion of our Getting Started 
+      guide will walk you through configuring a Kubernetes cluster.
+ 
+    %p  
+      %a( href="/docs/gettingstarted" ) &raquo; Get started with Kubernetes...
 
 -#.row{:style => 'clear:both'}
   .col-md-4.col-sm-12


### PR DESCRIPTION
Change k8s docs pointer to our new atomic-specific docs