### PR TITLE
typo: Fix run-on sentence in index.html.haml

### DIFF
--- a/source/docs/index.html.haml
+++ b/source/docs/index.html.haml
@@ -123,7 +123,7 @@ title: Project Atomic Documentation
   Most of the documents are simply written in the
   %a( href="http://en.wikipedia.org/wiki/Markdown" ) Markdown
   plain text formatting syntax, they are as a result easy to edit and
-  extend, simply clone the atomic site and edit them under the
+  extend. To change a document, clone the atomic site and make your edits under the
   %code sources/docs/
   directory. If you add a new file please also register it in
   %code data/docs.yml


### PR DESCRIPTION
Split info about the document format and how to edit a document into two sentences.