### PR TITLE
Adding build requirements for nokogiri 1.6.6.2 to yum install stanza

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:21
 MAINTAINER mscherer@redhat.com
 WORKDIR /tmp
 RUN yum upgrade -y 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:20
 MAINTAINER mscherer@redhat.com
 WORKDIR /tmp
 RUN yum upgrade -y 
-RUN yum install -y rubygem-bundler ruby-devel git make gcc gcc-c++
+RUN yum install -y libcurl-devel zlib-devel patch rubygem-bundler ruby-devel git make gcc gcc-c++
 
 ADD config.rb /tmp/config.rb
 ADD data /tmp/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM fedora:20
+FROM fedora:latest
 MAINTAINER mscherer@redhat.com
 WORKDIR /tmp
 RUN yum upgrade -y 
-RUN yum install -y libcurl-devel zlib-devel patch rubygem-bundler ruby-devel git make gcc gcc-c++
+RUN yum install -y tar libcurl-devel zlib-devel patch rubygem-bundler ruby-devel git make gcc gcc-c++
 
 ADD config.rb /tmp/config.rb
 ADD data /tmp/data


### PR DESCRIPTION
The Middleman build fails in this container with unresolved dependencies for the latest version of nokogiri.  Also the latest Fedora container doesn't pull in tar.

The missing dependencies are:
* tar
* libcurl-devel
* zlib-devel
* patch