### PR TITLE
blog: Use https for repo URL

### DIFF
--- a/source/blog/2015-06-30-creating-a-simple-bare-metal-atomic-host-cluster.html.md
+++ b/source/blog/2015-06-30-creating-a-simple-bare-metal-atomic-host-cluster.html.md
@@ -44,7 +44,7 @@ reboot
 %post
 ostree remote add --set=gpg-verify=false \
 	   Fedora-Cloud_Atomic \
-       'http://dl.fedoraproject.org/pub/fedora/linux/atomic/22/'
+       'https://dl.fedoraproject.org/pub/fedora/linux/atomic/22/'
 mkdir /var/cloud-init
 curl http://boothost/f22-atomic/meta-data.a1 > /var/cloud-init/meta-data
 curl http://boothost/f22-atomic/user-data > /var/cloud-init/user-data


### PR DESCRIPTION
The current default of http is insecure.