### PR TITLE
invalid docker command on <none> blog post

### DIFF
--- a/source/blog/2015-07-16-what-are-docker-none-none-images.html.md
+++ b/source/blog/2015-07-16-what-are-docker-none-none-images.html.md
@@ -75,7 +75,7 @@ If you remember `<none>:<none>` images listed in `docker images -a` are intermed
 The next command can be used to clean up these dangling images.
 
 ```
-docker rmi $(docker images -f “dangling=true” -q)
+docker rmi $(docker images --quiet --filter "dangling=true")
 ```
 
 Docker doesn’t have an automatic garbage collection system as of now. That would definitely be a nice feature to have. For now this command can be used to do a manual garbage collection.


### PR DESCRIPTION
@shishir-a412ed
Docker command in the blog post seems to be incorrect (tested on Docker 1.7).

```bash
wikus@wikus:~$ docker rmi $(docker images -f “dangling=true” -q)
Error response from daemon: Invalid filter '“dangling'
docker: "rmi" requires a minimum of 1 argument.
See 'docker rmi --help'.

Usage: docker rmi [OPTIONS] IMAGE [IMAGE...]

Remove one or more images
````

Working command:

```bash
wikus@wikus:~$ docker rmi $(docker images --quiet --filter "dangling=true")
Deleted: 259943fe4ae1973aa917d248b71f0ff9e9b5ce2121e9257dfac46d69db764b8e
Deleted: e8d864463cd2a3a209192fe7c3c5abe89eebdc9ab504420a18a8b38684a9de6e
Deleted: f23e80b38749dafe950d70ca237032396347a3dd3be59c0ff62ad8c7f162fa2b
Deleted: 0c708566983cafa63fb957f3e74ec031ffbf7cdcb48e21a4054a16b289ed3826
Deleted: b77249dc2ad7e7b74150f4a3d4a40437a1e34409a19b66c4892275af059014ef
```

