### PR TITLE
source/docs/nulecule: Prefix 'Nulecule specification' with 'The'

### DIFF
--- a/source/docs/nulecule.md
+++ b/source/docs/nulecule.md
@@ -21,7 +21,7 @@ Currently there is no standard mechanism to define a composite multi-container a
 
 Nulecule defines a pattern and model for packaging complex multi-container applications, referencing all their dependencies, including orchestration metadata in a container image for building, deploying, monitoring, and active management.
 
-Nulecule specification enables complex applications to be defined, packaged and distributed using standard container technologies. The resulting container includes dependencies while supporting multiple orchestration providers and ability to specify resource requirements. The Nulecule specification also supports aggregation of multiple composite applications. The Nulecule specification is container and orchestration agnostic, enabling the use of any container and orchestration engine.
+The Nulecule specification enables complex applications to be defined, packaged and distributed using standard container technologies. The resulting container includes dependencies while supporting multiple orchestration providers and ability to specify resource requirements. The Nulecule specification also supports aggregation of multiple composite applications. The Nulecule specification is container and orchestration agnostic, enabling the use of any container and orchestration engine.
 
 ## Nulecule Specification
 


### PR DESCRIPTION
To match the usage that the rest of these docs use.