### PR TITLE
Clarify documentation entry points and clean up quickstart

### DIFF
--- a/source/docs/quickstart.md
+++ b/source/docs/quickstart.md
@@ -1,12 +1,12 @@
 # Project Atomic Quick Start Guide
 
-We recommend reading the Getting Started Guide and Concepts Guide if you're entirely new to the concept of Atomic and Docker. But, we also wanted to provide a **Quick Start Guide** (or "guide for the impatient") for folks who just want to plow through and see what all the fuss is about. 
+We recommend reading the Getting Started Guide and Concepts Guide if you're entirely new to the concept of Atomic and Docker. But, we also wanted to provide a **Quick Start Guide** (or "guide for the impatient") for folks who just want to plow through and see what all the fuss is about.
 
 ## What You Need
 
 * **A virtualization client.** [Virtual Machine Manager](http://virt-manager.org/) (virt-manager) is a very good KVM-based client for Linux systems. Windows and OS X users can give [VirtualBox](https://www.virtualbox.org/) a try. Be sure your virtualization client is properly configured to access the Internet.
 
-* **A virtual machine image.** Images for Atomic hosts are produced by both the Fedora Project and the CentOS Project.  Downloads for these images can be found via the [Downloads page] (http://www.projectatomic.io/download/) in QCOW2, Vagrant Box, and RAW formats.
+* **A virtual machine image.** Images for Atomic hosts are produced by both the Fedora Project and the CentOS Project.  Downloads for these images can be found via the [Downloads page] (http://www.projectatomic.io/download/) in QCOW2, RAW, and Vagrant BOX formats.
 
 * **Note for VirtualBox users** At the moment, we are not producing native VirtualBox images, but you can generate your own VirtualBox image from the qcow2 images with `qemu-img`:
 
@@ -15,107 +15,119 @@ qemu-img convert -f qcow2 [filename].qcow2 -O vdi [filename].vdi
 
 ````
 
+## Step by Step
+There are three basic steps we'll do for each virtualization provider before booting the virtual machine:
 
-## Step by Step on virt-manager
+1. Prep the cloud-init source ISO
 
-Here's how to get started with Atomic on your machine using virt-manager on Linux. The instructions below are for running virt-manager on Fedora 21. The steps may vary slightly when running older distributions of virt-manager.
+2. Create the Atomic host virtual machine
 
-1. Download the KVM/QEMU image.
+3. Add and configure storage for Docker
 
-2. Run `xz -d [filename]` to uncompress the downloaded image.
+## Prep the cloud-init source ISO
 
-3. Start virt-manager.
-
-4. Run the File, New Virtual Machine menu command. The New VM dialog box will open.
-
-5. Select the Import existing disk image option and click Forward. The next page in the New VM dialog will appear.
-
-6. Click Browse. The Locate or create storage volume dialog will open.
-
-7. Click Browse Local. The Locate existing storage dialog will open.
-
-8. Navigate to the downloaded virtual machine file, select it, and click Open. The Locate existing storage dialog will close.
-
-9. In the New VM dialog, select Linux for the OS type, Fedora 20 (or later) for the Version, and click Forward. The next page in the New VM dialog will appear.
-
-10. Adjust the VM's RAM and CPU settings (if needed) and click Forward. The next page in the New VM dialog will appear.
-
-11. Assign a new name to the VM and click Finish. The Atomic instance will boot.
-
-**Note**: When running virt-manager on Red Hat Enterprise Linux 6 or CentOS 6, the VM **will not boot** until the disk storage format is changed from raw to qcow2.
-
-## Step by Step on VirtualBox
-
-Here's how to get started with Atomic on your machine using VirtualBox on Windows, OS X, or Linux.
-
-1. Download the qcow2 image of your choice (Fedora or CentOS).
-
-2. Convert the qcow2 image to vdi, using the instructions above.
-
-3. Start VirtualBox.
-
-4. Click the New icon on the VirtualBox toolbar. The Create Virtual Machine dialog box will open.
-
-5. Enter a name for the new machine, select Linux for the Type, Fedora (64 bit) for the Version, and click Next. The Memory Size page in the Create Virtual Machine dialog will appear.
-
-6. Adjust the VM's RAM if needed and click Next. The Hard Drive page in the Create Virtual Machine dialog will appear.
-
-7. Select the Use an existing virtual hard drive option, browse to the file location, and click Create. The virtual machine will be created and the virtual machine will be ready.
-
-## Logging In To Your Atomic Machine
-
-You will need to create a metadata ISO to supply data through [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) when your host boots. 
+In order to pass run time customizations to an Atomic host, we use cloud-init.  
+You will need to create a metadata ISO to supply critical data via [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) when your host boots.  You can pass system data via `meta-data` and configuration data via `user-data` files.  We will be setting up the password and adding an ssh key for the default user.  The metatdata ISO is created on the machine running your virtualization provider.
 
 1. Create a `meta-data` file with your desired hostname and any instance-id.
 
         $ cat meta-data
-        instance-id: id-local01
-        local-hostname: samplehost.example.org
+        instance-id: atomic-host001
+        local-hostname: atomic01.example.org
 
-2. Create a `user-data` file. The #cloud-config directive at the beginning of the file is mandatory.
+2. Create a `user-data` file. The #cloud-config directive at the beginning of the file is mandatory, not a comment.  If you have multiple admins and ssh keys you'd like to access the default user, you can add a new `ssh-rsa` line.  The
 
         $ cat user-data
         #cloud-config
-        password: mypassword 
+        password: atomic
         ssh_pwauth: True
         chpasswd: { expire: False }
-            
-        ssh_authorized_keys: 
+
+        ssh_authorized_keys:
           - ssh-rsa ... foo@bar.baz (insert ~/.ssh/id_rsa.pub here)
 
-3. After creating the `user-data` and `meta-data` files, generate an ISO. Make sure the user running libvirt has the proper permissions to read the generated image.
+3. After creating the `user-data` and `meta-data` files, generate an ISO file. Make sure the user running libvirt has the proper permissions to read the generated image.
 
         $ genisoimage -output init.iso -volid cidata -joliet -rock user-data meta-data
 
-#### virt-manager
+You'll add this ISO as a CD-ROM device in the virtual machine.
+
+## Create the Atomic host virtual machine
+
+We'll start with the QCOW2 format image for both virt-manager and VirtualBox.  For virt-manager, you will use this image directly. For VirtualBox, convert the QCOW2 to VDI in order to create an image suitable for VirtualBox.
+
+
+````
+qemu-img convert -f qcow2 [filename].qcow2 -O vdi [filename].vdi
+
+````
+
+### Creating with virt-manager
+
+Here's how to get started with Atomic on your machine using virt-manager on Linux. The instructions below are for running virt-manager on Fedora 21. The steps may vary slightly when running older distributions of virt-manager.
+
+1. Select `File` -> `New Virtual Machine` from the menu bar\. The New VM dialog box will open.
+
+2. Select the Import existing disk image option and click Forward. The next page in the New VM dialog will appear.
+
+3. Click `Browse`. The Locate or create storage volume dialog will open.
+
+4. Click `Browse Local`. The Locate existing storage dialog will open.
+
+5. Navigate to the downloaded virtual machine file, select it, and click `Open`.
+
+6. In the New VM dialog, select `Linux` for the OS type, `Fedora 21` (or later) for the Version, and click `Forward`.
+
+7. Adjust the VM's RAM and CPU settings (if needed) and click `Forward`.
+
+8. Select the checkbox next to `Customize configuration before install` and click `Forward`.  This will allow you to add the metatdata ISO device before booting the VM.
+
+**Note**: When running virt-manager on Red Hat Enterprise Linux 6 or CentOS 6, the VM **will not boot** until the disk storage format is changed from raw to qcow2.
+
+
+#### Adding the CD-ROM device for the metadata source
 
 1. In the virt-manager GUI, click to open your Atomic machine. Then on the top bar click *View > Details*
 2. Click on *Add Hardware* on the bottom left corner.
-3. Choose *Storage*, and *Select managed or other existing storage*. Browse and select the `init.iso` image you created. Change the *Device type* to CDROM device.  Click on *Finish* to create and attach this storage.
+3. Choose *Storage*, and *Select managed or other existing storage*. Browse and select the `init.iso` image you created. Change the *Device type* to CD-ROM device.  Click on *Finish* to create and attach this storage.
 
-#### VirtualBox
+### Creating with VirtualBox
+
+Here's how to get started with Atomic on your machine using VirtualBox on Windows, OS X, or Linux.
+
+1. Click the New icon on the VirtualBox toolbar. The Create Virtual Machine dialog box will open.
+
+2. Enter a name for the new machine, select `Linux` for the Type, `Fedora (64 bit)` for the Version, and click `Next`.
+
+3. Adjust the VM's RAM if needed and click `Next`.
+
+4. Select the `Use an existing virtual hard drive` option, browse to the file location, and click `Create`. The virtual machine will be created and the virtual machine will be ready.
+
+#### Adding the CD-ROM device for the metadata source
 
 1. In the VirtualBox GUI, click *Settings* for you Atomic virtual machine.
 2. On the *Storage* tab, for the IDE Controller, *Add CD/DVD Device*.
 3. Select *Choose Disk*, and select the `init.iso` you created.
 
-Boot the virtual machine with the disk attached and cloud-init will populate the default user information with the password or SSH keys you provided in the `user-data` file. **For a Fedora image, the default user is `fedora`, for CentOS the default user is `centos`.**
+## Exploring the Atomic host
+
+Boot the virtual machine with the CD-ROM attached and cloud-init will populate the default user information with the password or SSH keys you provided in the `user-data` file. **For a Fedora image, the default user is `fedora`, for CentOS the default user is `centos`.**
 
 Once you've booted and logged in to your Atomic host, you can update the system software with `$ sudo rpm-ostree upgrade` to pull in any updates.
 
-## Readying More Space For Containers
+### Add and configure storage for Docker
 
 Docker is ready to go at this point, but there's another fairly important bit of config to do, if you're going to be testing out more than a couple containers--you need to add a bigger drive for the docker LVM thin pool.
 
-### Add A New Drive in virt-manager
+#### Add A New Drive in virt-manager
 
 1. Select the View, Details menu command on your VM window.
 
-2. Click the Add Hardware. The Add New Virtual Hardware dialog box will open. 
+2. Click the Add Hardware. The Add New Virtual Hardware dialog box will open.
 
-3. Select Storage, change disk size to what you want, change bus type to VirtIO, and click Finish. The Add New Virtual Hardware dialog box will close. 
+3. Select Storage, change disk size to what you want, change bus type to VirtIO, and click Finish. The Add New Virtual Hardware dialog box will close.
 
-### Add A New Drive in VirtualBox
+#### Add A New Drive in VirtualBox
 
 1. With the Atomic VM closed, select the Machine, Settings menu command. The Settings dialog box will open.
 
@@ -134,7 +146,7 @@ Docker is ready to go at this point, but there's another fairly important bit of
 2. Open `/etc/sysconfig/docker-storage-setup` in an editor
 
 3. Add the new disk by creating a `DEVS` entry.  If you added more than one, you can add more to the list separated by a space.
-    
+
         DEVS="/dev/vdb"
 
 4. If you'd like to use some of the space on the new disk to grow the root volume, you can create a `ROOT_SIZE` with the new total size.

--- a/source/docs/quickstart.md
+++ b/source/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Project Atomic Quick Start Guide
 
-We recommend reading the Getting Started Guide and Concepts Guide if you're entirely new to the concept of Atomic and Docker. But, we also wanted to provide a **Quick Start Guide** (or "guide for the impatient") for folks who just want to plow through and see what all the fuss is about.
+We recommend reading the [Getting Started Guide](http://www.projectatomic.io/docs/gettingstarted) and Concepts Guide if you're entirely new to the concept of Atomic and Docker. But, we also wanted to provide a **Quick Start Guide** (or "guide for the impatient") for folks who just want to set up a single Atomic host and see what all the fuss around Docker and Atomic is about.
 
 ## What You Need
 
@@ -8,7 +8,7 @@ We recommend reading the Getting Started Guide and Concepts Guide if you're enti
 
 * **A virtual machine image.** Images for Atomic hosts are produced by both the Fedora Project and the CentOS Project.  Downloads for these images can be found via the [Downloads page] (http://www.projectatomic.io/download/) in QCOW2, RAW, and Vagrant BOX formats.
 
-* **Note for VirtualBox users** At the moment, we are not producing native VirtualBox images, but you can generate your own VirtualBox image from the qcow2 images with `qemu-img`:
+* **Note for VirtualBox users** We are not producing native VirtualBox images, but you can generate your own VirtualBox image from the qcow2 images with `qemu-img`:
 
 ````
 qemu-img convert -f qcow2 [filename].qcow2 -O vdi [filename].vdi
@@ -26,18 +26,19 @@ There are three basic steps we'll do for each virtualization provider before boo
 
 ## Prep the cloud-init source ISO
 
-In order to pass run time customizations to an Atomic host, we use cloud-init.  
-You will need to create a metadata ISO to supply critical data via [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) when your host boots.  You can pass system data via `meta-data` and configuration data via `user-data` files.  We will be setting up the password and adding an ssh key for the default user.  The metatdata ISO is created on the machine running your virtualization provider.
+In order to pass run time customizations to an Atomic host, we use [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) .  
 
-1. Create a `meta-data` file with your desired hostname and any instance-id.
+You will need to create a metadata ISO to supply critical data when your Atomic host boots.  System data is presented via the `meta-data` file and configuration data via the `user-data` file.  We will be setting up the password and ssh key for the default user.  The metatdata ISO is created on the machine running your virtualization provider.
 
-        $ cat meta-data
+1. Create a `meta-data` file with your desired hostname and instance-id.  If you need to change any of this information on a running host, you will need to increment the `instance-id`.  This is how `cloud-init` identifies a particular instance.
+
+        $ vi meta-data
         instance-id: atomic-host001
         local-hostname: atomic01.example.org
 
-2. Create a `user-data` file. The #cloud-config directive at the beginning of the file is mandatory, not a comment.  If you have multiple admins and ssh keys you'd like to access the default user, you can add a new `ssh-rsa` line.  The
+2. Create a `user-data` file. The #cloud-config directive at the beginning of the file is mandatory, not a comment.  If you have multiple admins and ssh keys you'd like to access the default user, you can add a new `ssh-rsa` line.
 
-        $ cat user-data
+        $ vi user-data
         #cloud-config
         password: atomic
         ssh_pwauth: True
@@ -136,8 +137,6 @@ Docker is ready to go at this point, but there's another fairly important bit of
 3. Select the Controller for the VM and click the Add Hard Disk icon. A Question dialog will open.
 
 4. Choose Create New Disk. The Create Virtual Hard Drive dialog box will open.
-
-5. Follow the steps 7-10 above used in creating a new VirtualBox VM to make a new hard drive for the VirtualBox VM.
 
 ### Configuring the New Drive
 

--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -22,7 +22,7 @@ title: Get Started with Project Atomic
   the "Boxes" virtual machine application available in
   <a href="http://fedoraproject.org/">Fedora</a> and <a href="http://centos.org/">CentOS 7</a>.
 %p
-  Feedora Vagrant images are also available for VirtualBox and libvirt/KVM providers, as are AMIs for running in EC2.
+  Fedora Vagrant images are also available for VirtualBox and libvirt/KVM providers, as are AMIs for running in EC2.
 %p.lead
 
 

--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -4,13 +4,14 @@ title: Get Started with Project Atomic
 
 %h1 Get Started with Atomic
 
+%h2 Download an Atomic Host image
+
 %img.pull-right( src="/images/platforms.png")
 
 %p.lead
-  Atomic Host images are now available from Fedora and the CentOS Project.
+  Atomic Host images are available from Fedora and the CentOS Project.  The <a href="http://wiki.centos.org/SpecialInterestGroup/Atomic">CentOS Atomic SIG</a> offers a rebuild of Red Hat Enterprise Linux Atomic Host on
+  <a href="http://cloud.centos.org/centos/7/atomic/images/">cloud.centos.org</a>.
 
-%p.lead
-  Fedora 22 Atomic Cloud is available as part of the <a href="https://getfedora.org/cloud/download/atomic.html">Fedora 22 Cloud</a> release.
 %p
   The "QCOW2" image works on Linux KVM virtualization, for example it runs on
   <a href="http://openstack.redhat.com/">RDO</a> (OpenStack),
@@ -21,8 +22,7 @@ title: Get Started with Project Atomic
 %p
   Vagrant images are also available for VirtualBox and libvirt/KVM providers, as are AMIs for running in EC2.
 %p.lead
-  The <a href="http://wiki.centos.org/SpecialInterestGroup/Atomic">CentOS Atomic SIG</a> offers a rebuild of Red Hat Enterprise Linux Atomic Host on 
-  <a href="http://cloud.centos.org/centos/7/atomic/images/">cloud.centos.org</a>.
+
 
 .clearfix
 
@@ -38,7 +38,7 @@ title: Get Started with Project Atomic
 
 .row
   .col-md-12.sm-12
-    %h2 Setting Up the Virtual Machine
+    %h2 Set Up the Virtual Machine
 
     %p
       Please follow the
@@ -46,16 +46,26 @@ title: Get Started with Project Atomic
       to create a new virtual machine with Atomic and set
       up more disk space for your containers.
 
+    %h2 Configure an Atomic cluster
+
+    %p
+      Atomic hosts are either used in a standalone configuration to run Docker containers or in an orchestrated cluster to run Kubernetes pods.
+      You can use the
+      %a( href="/docs/gettingstarted" ) Getting Started Guide
+      to set up a cluster.  You can run a standalone configuration after completing the Quick Start guide.
+
+-#.row{:style => 'clear:both'}
     %h3 Extremely Quick Start Guide For the Impatient
 
     %p
       From here in, we'll refer to the Atomic VM as the "host," even though it's actually a VM. Atomic boots to a text console, asking you to log in.
       You need to create a metadata ISO for use with <a href="http://cloudinit.readthedocs.org/en/latest/">cloud-init</a>.
 
-      For example instructions on creating one, see: <a href="https://www.technovelty.org//linux/running-cloud-images-locally.html">this blog entry</a>.
+      For example instructions on creating one, see:
+      %a( href="/blog/2014/10/getting-started-with-cloud-init/" ) this blog entry.
 
   .col-md-6.col-sm-12
-    %h2 Atomic Upgrades
+    %h4 Atomic Upgrades
 
     %p
       From a running host, start an upgrade with:
@@ -70,7 +80,7 @@ title: Get Started with Project Atomic
       %a( href="/docs/os-updates" ) &raquo; More on atomic upgrades with OSTree...
 
   .col-md-6.col-sm-12
-    %h2 Docker Containers
+    %h4 Docker Containers
 
     %p
       Host applications on Atomic with #{link_to "Docker", "https://www.docker.io"}
@@ -84,9 +94,10 @@ title: Get Started with Project Atomic
     %p
       %a( href="/docs/#docker" ) &raquo; Read about Docker in production...
 
-.row
+
+-#.row{:style => 'clear:both'}
   .col-md-6.col-sm-12
-    %h2 Try the New UI for Your Server
+    %h4 Try the New UI for Your Server
 
     %p
       Administer the services on your system with Cockpit (Preview - not for production use)
@@ -109,7 +120,7 @@ title: Get Started with Project Atomic
       %a( href="http://cockpit-project.org" ) &raquo; Visit cockpit-project.org...
 
   .col-md-6.col-sm-12
-    %h2 Learn about Kubernetes
+    %h4 Learn about Kubernetes
 
     %p
       If you're looking to work with orchestration, you'll want

--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -9,8 +9,10 @@ title: Get Started with Project Atomic
 %img.pull-right( src="/images/platforms.png")
 
 %p.lead
-  Atomic Host images are available from Fedora and the CentOS Project.  The <a href="http://wiki.centos.org/SpecialInterestGroup/Atomic">CentOS Atomic SIG</a> offers a rebuild of Red Hat Enterprise Linux Atomic Host on
-  <a href="http://cloud.centos.org/centos/7/atomic/images/">cloud.centos.org</a>.
+  Atomic Host images are provided by the Fedora and the CentOS Projects.
+%p
+  The <a href="https://fedoraproject.org/wiki/Cloud_SIG">Fedora Cloud SIG</a> offers a new Fedora product Atomic Cloud Image.
+  The <a href="http://wiki.centos.org/SpecialInterestGroup/Atomic">CentOS Atomic SIG</a> offers a rebuild of Red Hat Enterprise Linux Atomic Host.
 
 %p
   The "QCOW2" image works on Linux KVM virtualization, for example it runs on
@@ -20,7 +22,7 @@ title: Get Started with Project Atomic
   the "Boxes" virtual machine application available in
   <a href="http://fedoraproject.org/">Fedora</a> and <a href="http://centos.org/">CentOS 7</a>.
 %p
-  Vagrant images are also available for VirtualBox and libvirt/KVM providers, as are AMIs for running in EC2.
+  Feedora Vagrant images are also available for VirtualBox and libvirt/KVM providers, as are AMIs for running in EC2.
 %p.lead
 
 
@@ -44,7 +46,7 @@ title: Get Started with Project Atomic
       Please follow the
       %a( href="/docs/quickstart/" ) Quick Start Guide
       to create a new virtual machine with Atomic and set
-      up more disk space for your containers.
+      up more disk space for your containers.  This guide will set up a single host capable of running Docker containers.
 
     %h2 Configure an Atomic cluster
 


### PR DESCRIPTION
I've talked to a few folks who didn't realize we had more than the quickstart guide.  The main confusion came from the layout of the page that is listed as "Getting Started" in the nav bar, but started life as the downloads page.  

I put a bigger emphasis on the GSG and the Quickstart guide as the entry points, and cleaned up some language.  I also removed the Extreme Quickstart, that was what some folks thought were "the official instructions".

I also reflowed the Quickstart guide to put more emphasis on the steps rather than the virtualization providers to eliminate duplication.

Thoughts?