### PR TITLE
update download page to point at centos wiki

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -22,7 +22,7 @@ title: Get Started with Project Atomic
   the "Boxes" virtual machine application available in
   <a href="http://fedoraproject.org/">Fedora</a> and <a href="http://centos.org/">CentOS 7</a>.
 %p
-  Fedora Vagrant images are also available for VirtualBox and libvirt/KVM providers, as are AMIs for running in EC2.
+  Both the Fedora and CentOS Atomic Host images are also available in Vagrant format, for use with the VirtualBox and libvirt/KVM providers, as well as in AMI format for running in EC2, and as ISO images for bare-metal installations.
 %p.lead
 
 
@@ -32,9 +32,8 @@ title: Get Started with Project Atomic
   %a.btn.btn-primary.btn-lg{:href => "https://getfedora.org/cloud/download/atomic.html"} Fedora Atomic Host
 
 %p.buttons.hidden-xs
-  %a.btn.btn-primary.btn-lg{:href => "http://cloud.centos.org/centos/7/atomic/images/"} CentOS Atomic Host
+  %a.btn.btn-primary.btn-lg{:href => "https://wiki.centos.org/SpecialInterestGroup/Atomic/Download/"} CentOS Atomic Host
 
-%p A bare-metal installer based on Fedora 22 is also <a href="http://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud_Atomic/x86_64/iso/Fedora-Cloud_Atomic-x86_64-22.iso">available</a>.
 
 .clearfix
 


### PR DESCRIPTION
Point to download page on centos wiki, point out that vagrant and iso images exist for centos, as well.