### PR TITLE
Suggested changes to DNS lead sentence

### DIFF
--- a/source/blog/2015-10-05-setting-up-skydns.html.md
+++ b/source/blog/2015-10-05-setting-up-skydns.html.md
@@ -7,7 +7,7 @@ comments: true
 published: true
 ---
 
-Kubernetes is (currently) missing an integrated dns solution for service discovery. In the future it will be integrated into `kubernetes` (see [PR11599](https://github.com/kubernetes/kubernetes/pull/11599)) but for now we have to setup [SkyDNS](https://github.com/skynetservices/skydns) manually.
+Kubernetes exposes DNS for service discovery, but the DNS server itself must be configured after you install Kubernetes. In the future it will be integrated into `kubernetes` as part of the platform (see [PR11599](https://github.com/kubernetes/kubernetes/pull/11599)) but for now you have to setup and run the [SkyDNS](https://github.com/skynetservices/skydns) container yourself.
 
 I have seen some tutorials on how to get `skydns` working, but almost all of them are rather involved. However, if you just want a simple setup on a single node for testing then it is actually rather easy to get `skydns` set up.
 


### PR DESCRIPTION
Someone mentioned the first sentence was confusingly phrased (implying Kube doesn't have DNS today) so I've reworded it to make it clearer that the server must be run on top of the cluster.