### PR TITLE
Clarify where is atomic

### DIFF
--- a/source/docs/usr-bin-atomic.md
+++ b/source/docs/usr-bin-atomic.md
@@ -11,7 +11,7 @@ The goal of `atomic` is to provide a high-level, coherent entrypoint for the sys
 
 ### Note about Atomic
 
-The `atomic` command is still a bit new and undergoing rapid development. It is currently in Fedora 22 alpha and will soon be included in the CentOS Atomic host builds.
+The `atomic` command is still a bit new and undergoing rapid development. It is currently in the Fedora and CentOS Atomic host builds.
 
 ## Using /usr/bin/atomic
 


### PR DESCRIPTION
Sinceall supported Fedora and Centos atomic build host support atomic,
no need to say this is Fedora 22 alpha.