### PR TITLE
Remove links to rpm-ostree.cloud.fedoraporject.org

### DIFF
--- a/source/community/index.html.haml
+++ b/source/community/index.html.haml
@@ -21,7 +21,7 @@ title: Welcome to the Atomic community
   system and service manager,
   <a href="https://wiki.gnome.org/Projects/OSTree">OSTree</a>
   and
-  <a href="http://rpm-ostree.cloud.fedoraproject.org/">rpm-ostree</a>
+  <a href="https://github.com/projectatomic/rpm-ostree">rpm-ostree</a>
   for updates,
   <a href="https://www.docker.io/">Docker</a>
   for application deployment, 
@@ -107,7 +107,7 @@ title: Welcome to the Atomic community
   technical options on the list, answer newcomers' questions in the forum,
   take part in the development of the upstream projects we use,
   help us integrate into the existing distrbutions
-  <a href="http://rpm-ostree.cloud.fedoraproject.org/">Fedora</a>
+  <a href="https://github.com/projectatomic/rpm-ostree">Fedora</a>
   and
   <a href="http://wiki.centos.org/Cloud">CentOS</a>. You can also help us to port Atomic so that it can use different
   formats or be usable on other distributions. Can't code? Help us by


### PR DESCRIPTION
http://rpm-ostree.cloud.fedoraporject.org serves up the default apache page, I'm not sure what used to live there but should we remove these links?