### PR TITLE
Updated to Fedora 22 in order to have the build continue to work (som…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:21
+FROM fedora:22
 MAINTAINER mscherer@redhat.com
 WORKDIR /tmp
 RUN yum upgrade -y 


### PR DESCRIPTION
…e Fedora21 repos seem to be no longer available).  Note that build on Fedora23 failed; making the build work with Fedora23 is still a todo.