### PR TITLE
add github edit link to page footer (except blog)

### DIFF
--- a/data/site.yml
+++ b/data/site.yml
@@ -15,6 +15,9 @@ has_comments: true
 # If no owner is specified, then copyright will default to site name.)
 owner: Project Atomic. Sponsored by Red Hat, Inc.
 
+# Location where this repo exists on github
+github: projectatomic/atomic-site
+
 # The year your site was established (for the copyright)
 founding_year: 2014 # Defaults to current year if commented
 

--- a/source/layouts/_footer.haml
+++ b/source/layouts/_footer.haml
@@ -18,6 +18,13 @@
 
       = data.site.copyright || "&copy; #{year_string} #{data.site.owner || data.site.name}"
 
+      - if data.site.github && !current_page.path.match(/blog/)
+        .edit-this-page.pull-right
+          - icon = '<i class="icon fa fa-fw fa-github"></i>'
+          - source_file = current_page.source_file.sub(root, '')
+          - github_url = "https://github.com/#{data.site.github}/edit/master#{source_file}"
+          = link_to "#{icon}Edit this page on GitHub", github_url
+
       ~ insert_piwik_tracker
       -# .last-modified
         - modified_time = IO.popen(['git', 'log', '--pretty=format:%ai', current_page.source_file]).read.split(/\n/).first rescue nil
@@ -25,3 +32,4 @@
         - if modified_time
           Page last modified
           = Time.parse(modified_time).utc.strftime('%a %-d %b %Y %H:%M %Z')
+         


### PR DESCRIPTION
This might be handy for quick edits to get more contributions? It shows an "edit this on github" link for all pages except for the blog (where it kinda makes less sense)

I tried to think of any other pages where it wouldnt make sense but none occurred to me immediately.
