### PR TITLE
announce feed in blog page's header

### DIFF
--- a/source/blog.html.haml
+++ b/source/blog.html.haml
@@ -3,6 +3,9 @@ title: Project Atomic News
 pageable: true
 ---
 
+- content_for :head do
+  %link(href="/blog/feed.xml" rel="alternate" title="Atom feed" type="application/atom+xml")
+
 %section.blog-archive
 
   %h1 Project News


### PR DESCRIPTION
While I agree we should make the feed link more visible, this adds the feed link to the head section of the blog index page. Individual articles had this already, but looks like it was missing from /blog/ itself. I guess some feed readers can pick it up from there.

Let's discuss the feed icon etc separately, that might be a good idea too.