### PR TITLE
Update Atomic App documentation

### DIFF
--- a/source/docs/atomicapp.md
+++ b/source/docs/atomicapp.md
@@ -3,11 +3,13 @@ title: "Atomic App"
 ---
 # What is Atomic App?
 
-Atomic App is a reference implementation of the [Nulecule Specification](https://github.com/projectatomic/nulecule). It can be used to bootstrap container applications and to install and run them. Atomic App is designed to be run in a container context. Examples using this tool may be found in the [Nulecule examples library](https://github.com/projectatomic/nulecule-library).
+[Atomic App](https://github.com/projectatomic/atomicapp) is a reference implementation of the [Nulecule Specification](https://github.com/projectatomic/nulecule). It can be used to bootstrap container applications and to install and run them. Atomic App is designed to be run in a container context. 
+
+Examples using this tool may be found in the [Nulecule examples library](https://github.com/projectatomic/nulecule-library).
 
 ## Getting Started
 
-Atomic App itself is packaged as a container. End-users typically do not install the software from source. Instead use the atomicapp container as the `FROM` line in a Dockerfile and package your application on top. For example:
+Atomic App itself is packaged as a container. End-users typically do not install the software from source. Instead using the `atomicapp` container as the `FROM` line in a Dockerfile and packaging your application on top. For example:
 
 ```
 FROM projectatomic/atomicapp
@@ -15,60 +17,82 @@ FROM projectatomic/atomicapp
 MAINTAINER Your Name <you@example.com>
 
 ADD /nulecule /Dockerfile README.md /application-entity/
-ADD /artifacts /application-entity/artifacts
+ADD /artifacts /application-entity /artifacts
 ```
+For more information see the [extensive Atomic App getting started guide](https://github.com/projectatomic/atomicapp/blob/master/docs/start_guide.md) which goes over in detail on how to build your first Atomic App container.
 
-For more information see the [Nulecule getting started guide](https://github.com/projectatomic/nulecule/blob/master/docs/getting-started.md).
+## Running your first Nulecule
 
-## Developers
 
-Step 1 - clone the github repository: `git clone https://github.com/projectatomic/atomicapp`.
+### Install Atomic App
 
-### Install this project
-Simply run
-
-```
-pip install .
-```
-
-If you want to make some changes to the code, setting these environment variables will help:
+Clone the github repository
 
 ```
+git clone https://github.com/projectatomic/atomicapp
 cd atomicapp
-export PYTHONPATH=`pwd`:$PYTHONPATH
-alias atomicapp="`pwd`/atomicapp/cli/main.py"
 ```
 
-### Build
-```
-atomicapp [--dry-run] build [TAG]
-```
+Install it
 
-Calls 'docker build' to package up the application and tags the resulting image.
-
-### Install and Run
 ```
-atomicapp [--dry-run] [-a answers.conf] install|run [--recursive] [--update] [--destination DST_PATH] APP|PATH
+sudo make install
 ```
 
-Pulls the application and it's dependencies. If the last argument is
-existing path, it looks for `Nulecule` file there instead of pulling anything.
+### Running Atomic App
 
-* `--recursive yes|no` Pull whole dependency tree
-* `--update` Overwrite any existing files
+This will run a helloworld example using the `centos/apache` container image on Kubernetes.
+```
+sudo atomicapp run projectatomic/helloapache 
+```
+
+Same with Docker.
+```
+sudo atomicapp run projectatomic/helloapache --provider=docker
+```
+
+### Fetching, modifying and running an Atomic App
+
+Fetch a Nuleculized container, modify the answers file and launch it.
+```
+atomicapp fetch projectatomic/helloapache --destination helloapache
+cd helloapache
+cp answers.conf.sample answers.conf # Modify then copy answers.conf.sample
+atomicapp run .
+```
+
+### Commands
+```
+atomicapp {run,fetch,stop,genanswers,init} APP|PATH [--dry-run] [-a answers.conf] [-v] [--namespace foo] [--destination foo]
+```
+
+Pulls the application and it's dependencies. If the last argument is an existing path, it looks for `Nulecule` file there instead of pulling the container.
+
 * `--destination DST_PATH` Unpack the application into given directory instead of current directory
 * `APP` Name of the image containing the application (f.e. `vpavlin/wp-app`)
 * `PATH` Path to a directory with installed (i.e. result of `atomicapp install ...`) app
-
-Action `run` performs `install` prior it's own tasks are executed if `APP` is given. When `run` is selected, providers' code is invoked and containers are deployed.
+* `--dry-run` Performs a faux command of Atomic App to simulate a deployment scenario
+* `-a answers.conf` Provide an answers.conf file when deploying a container
+* `--namespace foo` Use a particular namespace for a specific provider (specifically, k8s and openshift)
 
 ## Providers
 
-Providers represent various deployment targets. They can be added by placing a file called `provider_name.py` in `providers/`. This file needs to implement the interface explained in (providers/README.md). For a detailed description of all providers available see the [Provider description](https://github.com/projectatomic/atomicapp/blob/master/docs/providers.md).
+Atomic App currently supports the following providers:
 
-##Communication channels
+* Kubernetes
+* OpenShift
+* Marathon
+* Docker
+
+## Contribution
+
+Interested in contributing? We have an awesome [development guide to get you started](https://github.com/projectatomic/atomicapp/blob/master/CONTRIBUTING.md)!
+
+## Communication channels
 
 Interested in **Atomic App**? We'd love to hear from you about your use of Atomic App and work together on improving it.
 
-* IRC: #nulecule (On Freenode)
+* IRC: __#nulecule__ on irc.freenode.net
 * Mailing List: [container-tools@redhat.com](https://www.redhat.com/mailman/listinfo/container-tools)
+* Weekly IRC Nulecule meeting: Monday's @ 0930 EST / 0130 UTC
+* Weekly SCRUM Container-Tools meeting: Wednesday's @ 0830 EST / 1230 UTC on [Bluejeans](https://bluejeans.com/381583203/)


### PR DESCRIPTION
This documentation is largely outdated and needs to be updated to
everything that's new in Atomic App.

For example, we no longer use `atomicapp build`.