### PR TITLE
download: Reorder to have CentOS first

### DIFF
--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -11,8 +11,11 @@ title: Get Started with Project Atomic
 %p.lead
   Atomic Host images are provided by the Fedora and the CentOS Projects.
 %p
-  The <a href="https://fedoraproject.org/wiki/Cloud_SIG">Fedora Cloud SIG</a> offers a new Fedora product Atomic Cloud Image.
-  The <a href="http://wiki.centos.org/SpecialInterestGroup/Atomic">CentOS Atomic SIG</a> offers a rebuild of Red Hat Enterprise Linux Atomic Host.
+The <a href="http://wiki.centos.org/SpecialInterestGroup/Atomic">CentOS
+Atomic SIG</a> offers a rebuild of Red Hat Enterprise Linux Atomic
+Host, considered a stable target.
+
+The <a href="https://fedoraproject.org/wiki/Cloud_SIG">Fedora Cloud SIG</a> offers a new Fedora product Atomic Cloud Image.
 
 %p
   The "QCOW2" image works on Linux KVM virtualization, for example it runs on
@@ -29,11 +32,10 @@ title: Get Started with Project Atomic
 .clearfix
 
 %p.buttons.hidden-xs
-  %a.btn.btn-primary.btn-lg{:href => "https://getfedora.org/cloud/download/atomic.html"} Fedora Atomic Host
-
-%p.buttons.hidden-xs
   %a.btn.btn-primary.btn-lg{:href => "https://wiki.centos.org/SpecialInterestGroup/Atomic/Download/"} CentOS Atomic Host
 
+%p.buttons.hidden-xs
+  %a.btn.btn-primary.btn-lg{:href => "https://getfedora.org/cloud/download/atomic.html"} Fedora Atomic Host
 
 .clearfix
 


### PR DESCRIPTION
This is a tricky balance but I think we should point people at more
production configurations first.  Fedora and CAHC should more be
development options.