### PR TITLE
Update gettingstarted.md

### DIFF
--- a/source/docs/gettingstarted.md
+++ b/source/docs/gettingstarted.md
@@ -208,7 +208,7 @@ Using a systemd drop-in file allows us to override the distributed systemd unit 
     EnvironmentFile=/run/flannel/subnet.env
     ExecStartPre=-/usr/sbin/ip link del docker0
     ExecStart=
-    ExecStart=/usr/bin/docker -d \
+    ExecStart=/usr/bin/docker daemon \
           --bip=${FLANNEL_SUBNET} \
           --mtu=${FLANNEL_MTU} \
           $OPTIONS \


### PR DESCRIPTION
The Fedora-based Atomic Host Image is now Fedora 24, which ships with Docker version 1.10.3. 'docker -d' no longer works in this version of Docker. 'docker daemon' works on both the current stable versions of CentOS-based and Fedora-based Atomic Host Image.