### PR TITLE
Fixed SASS warning

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -33,7 +33,7 @@ blog_summary_length: 500
 
   %hr
 
-  .col-md-12#secondary
+  .col-md-12
     .row
       .col-xs-12.col-lg-4
 

--- a/source/stylesheets/_application-custom.css.sass
+++ b/source/stylesheets/_application-custom.css.sass
@@ -83,7 +83,7 @@
   @media screen and (min-width: $screen-sm)
     padding-left: $grid-gutter-width
     padding-right: $grid-gutter-width
-    .index & 
+    .index &
       padding-left: $grid-gutter-width/2
       padding-right: $grid-gutter-width/2
 
@@ -159,14 +159,12 @@
   h2
     margin-top: 0
 
-#secondary   
-  
 #footer
   background: $gray-lighter
   font-size: $font-size-small
   padding-bottom: 20px
   padding-top: 20px
-  
+
   @media screen and (min-width: $screen-md)
     padding-left: $grid-gutter-width
     padding-right: $grid-gutter-width
@@ -205,7 +203,7 @@
     @media (min-width: $grid-float-breakpoint) and (max-width: $screen-md - 1)
       margin-left: $grid-gutter-width
 
-      .index & 
+      .index &
         margin-left: $grid-gutter-width
 
     @media (min-width: $screen-md)


### PR DESCRIPTION
I was getting the annoying CSS warning as :

```
.....
WARNING on line 163 of /tmp/source/stylesheets/_application-custom.css.sass:
This selector doesn't have any properties and will not be rendered.
```

Please feel free to the discard PR if you think `#secondary` needs some content. 
