### PR TITLE
Added blog post and table of patches.

### DIFF
--- a/source/blog/2016-08-18-docker-patches.html.md
+++ b/source/blog/2016-08-18-docker-patches.html.md
@@ -7,13 +7,13 @@ published: true
 comments: true
 ---
 
-Project Atomic's version of the docker-based container runtime has been carrying a series of patches on the upstream docker project for a while now.  Each time we carry a patch, it adds significant effort as we continue to track upstream, therefore we would prefer to never carry any patches.  We always strive to get our patches upstream and do it in the open.
+Project Atomic's version of the Docker-based container runtime has been carrying a series of patches on the upstream Docker project for a while now.  Each time we carry a patch, it adds significant effort as we continue to track upstream, therefore we would prefer to never carry any patches.  We always strive to get our patches upstream and do it in the open.
 
 This post, and the accompanying document, will attempt to describe the patches we are currently carrying:
 
-* Explanation on types of patches
-* Description of patches
-* Links to GitHub discussions and pull requests for upstreaming the patches to docker.
+* Explanation on types of patches. 
+* Description of patches.
+* Links to GitHub discussions, and pull requests for upstreaming the patches to docker.
 
 Some people have asserted that [our docker repo](https://github.com/projectatomic/docker) is a fork of the upstream docker project.
 
@@ -21,11 +21,13 @@ Some people have asserted that [our docker repo](https://github.com/projectatomi
 
 I have been in open source for a long time, and my definition of a "fork" might be dated. I think of a "fork" as a hostile action taken by one group to get others to use and contribute to their version of an upstream project and ignore the "original" version. For example, LibreOffice forking off of OpenOffice or going way back Xorg forking off of Xfree86.
 
-Nowadays, GitHub has changed the meaning. When a software repository exists on GitHub or a similar platform, everyone who wants to contribute has to hit the "fork" button, and start building their patches. As of this writing, docker on GitHub has 9860 forks, including ours. By this definition, however, all packages that distributions ship that include patches are forks. Red Hat ships the Linux Kernel, and I have not heard this referred to as a fork. *The docker upstream even relies on Ubuntu carrying patches for AUFS that were never merged into the upstream kernel.* Since Red Hat-based distributions don’t carry the AUFS patches, we contributed the support for Devicemapper, OverlayFS, and BTRFS backends, which are fully supported in the upstream kernel.  This is what enterprise distributions should do: attempt to ship packages configured in a way that they can be supported for a long time.
+Nowadays, GitHub has changed the meaning. When a software repository exists on GitHub or a similar platform, everyone who wants to contribute has to hit the "fork" button, and start building their patches. As of this writing, Docker on GitHub has 9,860 forks, including ours. By this definition, however, all packages that distributions ship that include patches are forks. Red Hat ships the Linux Kernel, and I have not heard this referred to as a fork. But it would be considered a "fork" if you're considering any upstream project shipped with patches a fork.
 
-At the end of the day, we continue to track the changes made to the upstream docker project and re-apply our patches to that project. We believe this is an important distinction to allow freedom in software to thrive while continually building stronger communities.  It’s very different than a hostile fork that divides communities&mdash;we are still working very hard to maintain continuity around unified upstreams.
+*The Docker upstream even relies on Ubuntu carrying patches for AUFS that were never merged into the upstream kernel.* Since Red Hat-based distributions don’t carry the AUFS patches, we contributed the support for Devicemapper, OverlayFS, and Btrfs backends, which are fully supported in the upstream kernel.  This is what enterprise distributions should do: attempt to ship packages configured in a way that they can be supported for a long time.
 
-## How Can I Find Out About Patches for a Particular Version of docker?
+At the end of the day, we continue to track the changes made to the upstream Docker Project and re-apply our patches to that project. We believe this is an important distinction to allow freedom in software to thrive while continually building stronger communities.  It’s very different than a hostile fork that divides communities&mdash;we are still working very hard to maintain continuity around unified upstreams.
+
+## How Can I Find Out About Patches for a Particular Version of Docker?
 
 All of the patches we ship are described in the README.md file on the appropriate branch of [our docker  repository](https://github.com/projectatomic/docker). If you want to look at the patches for docker-1.12 you would look at [the docker-1.12 branch](https://github.com/projectatomic/docker/tree/docker-1.12).
 
@@ -33,20 +35,26 @@ You can then look on the [docker patches list page](/docs/docker_patches) for in
 
 ## What Kind of Patches does Project Atomic Include?
 
-Here is a quick overview of our included patches.
+Here is a quick overview of the kinds of patches we carry, and then guidance on finding information on specific patches.
 
 ### Upstream Fixes
 
-The upstream docker project tends to fix issues in the **next** version of docker. This means if a user finds an issue in docker-1.11 and we provide a fix for this to upstream, the patch gets merged in to the master branch, and it will probably not get back ported to docker-1.11. Since docker is releasing at such a rapid rate, they tell users to just install docker-1.12 when it is available. This is fine for people who want to be on the bleeding edge, but in a lot of cases the newer version of docker comes with new issues along with the fixes. For example, docker-1.11 split the docker daemon into three parts: docker daemon, containerd, and runc.  We did not feel this was stable enough to ship to enterprise customers right when it came out, yet it had multiple fixes for the docker-1.10 version. Many users want to only get new fixes to their existing software and not have to re-certify their apps every two months.
+The Docker Project upstream tends to fix issues in the **next** version of Docker. This means if a user finds an issue in docker-1.11 and we provide a fix for this to upstream, the patch gets merged in to the master branch, and it will probably not get back ported to docker-1.11. 
 
-Another issue with supporting stable software with rapidly changing dependencies is that developers on the stable projects must spend time ensuring that their product remains stable every time one of their dependencies is updated. This is an expensive process, dependencies end up being updated only infrequently. This causes us to "cherry-pick" fixes from upstream docker and to ship these fixes on older versions so that we can get the benefits from the bug fixes without the cost of updating the entire dependency. This is the same approach we take in order to add capabilities to the Linux kernel, a practice that has proven to be very valuable to our users.
+Since Docker is releasing at such a rapid rate, they tell users to just install docker-1.12 when it is available. This is fine for people who want to be on the bleeding edge, but in a lot of cases the newer version of Docker comes with new issues along with the fixes. 
+
+For example, docker-1.11 split the docker daemon into three parts: docker daemon, containerd, and runc.  We did not feel this was stable enough to ship to enterprise customers right when it came out, yet it had multiple fixes for the docker-1.10 version. Many users want to only get new fixes to their existing software and not have to re-certify their apps every two months. 
+
+Another issue with supporting stable software with rapidly changing dependencies is that developers on the stable projects must spend time ensuring that their product remains stable every time one of their dependencies is updated. This is an expensive process, dependencies end up being updated only infrequently. This causes us to "cherry-pick" fixes from upstream Docker and to ship these fixes on older versions so that we can get the benefits from the bug fixes without the cost of updating the entire dependency. This is the same approach we take in order to add capabilities to the Linux kernel, a practice that has proven to be very valuable to our users.
 
 ### Proposed Patches for Upstream
 
-We carry patches that we know our users require right now, but have not yet been merged into the upstream project.  Every patch that we add to the Project Atomic repository also gets proposed to the upstream docker repository. These sorts of patches remain on the Project Atomic repository briefly while they’re being considered upstream, or forever if the upstream community rejects them. If we don't agree with upstream docker and feel our users need these patches, we continue to carry them. In some cases we have worked out alternative solutions like building authorization plugins. 
+We carry patches that we know our users require right now, but have not yet been merged into the upstream project.  Every patch that we add to the Project Atomic repository also gets proposed to the upstream docker repository. 
+
+These sorts of patches remain on the Project Atomic repository briefly while they’re being considered upstream, or forever if the upstream community rejects them. If we don't agree with upstream Docker and feel our users need these patches, we continue to carry them. In some cases we have worked out alternative solutions like building authorization plugins. 
 
 For example, users of RHEL images are not supposed to push these image onto public web sites. We wanted a way to prevent users from accidentally pushing RHEL based images to Docker Hub, so we originally created a patch to block the pushing.  When authorization plugins were added we then created a plugin to protect users from pushing RHEL content to a public registry like Docker Hub, and no longer had to carry the custom patch.
 
 ## Detailed List of Patches
 
-You can find the current table and list of patches on our new [docker patches list page](/docs/docker_patches).
+Want to know more about specific patches? You can find the current table and list of patches on our new [docker patches list page](/docs/docker_patches).

--- a/source/blog/2016-08-18-docker-patches.html.md
+++ b/source/blog/2016-08-18-docker-patches.html.md
@@ -7,7 +7,7 @@ published: true
 comments: true
 ---
 
-Project Atomic's version of the docker-based container runtime has been carrying a series of patches on the upstream docker project for a while now.  Each time we carry a patch it adds significant effort as we continue to track upstream, therefore we would prefer to never carry any patches.  We always strive to get our patches upstream and do it in the open.
+Project Atomic's version of the docker-based container runtime has been carrying a series of patches on the upstream docker project for a while now.  Each time we carry a patch, it adds significant effort as we continue to track upstream, therefore we would prefer to never carry any patches.  We always strive to get our patches upstream and do it in the open.
 
 This post, and the accompanying document, will attempt to describe the patches we are currently carrying:
 
@@ -17,32 +17,36 @@ This post, and the accompanying document, will attempt to describe the patches w
 
 Some people have asserted that [our docker repo](https://github.com/projectatomic/docker) is a fork of the upstream docker project.
 
-##  What does it mean to be a fork?
+##  What Does It Mean To Be a Fork?
 
-I have been in open source for a long time, and my definition of a "fork" might be dated.  I think of a "fork" as a hostile action taken by one group to get others to use and contribute to their version of an upstream project and ignore the "original" version.  For example LibreOffice forking off of OpenOffice or going way back Xorg forking off of Xfree86.
+I have been in open source for a long time, and my definition of a "fork" might be dated. I think of a "fork" as a hostile action taken by one group to get others to use and contribute to their version of an upstream project and ignore the "original" version. For example, LibreOffice forking off of OpenOffice or going way back Xorg forking off of Xfree86.
 
-Nowadays, GitHub has changed the meaning.  When a software repository exists on GitHub or similar, everyone who wants to contribute has to hit the "fork" button, and start building their patches.  As of this writing, docker on GitHub has 9860 forks, including ours.   By this definition, however, all packages that distributions ship that include patches are forks. Red Hat ships the Linux Kernel, and I have not heard this referred to as a fork. *The docker upstream even relies on Ubuntu carrying patches for AUFS that were never merged into the upstream kernel.*  Since Red Hat-based distributions don’t carry the AUFS patches, we contributed the support for Devicemapper, OverlayFS and BTRFS backends, that are fully supported in the upstream kernel.  This is what enterprise distributions should do: attempt to ship packages configured in a way that they can be supported for a long time.
+Nowadays, GitHub has changed the meaning. When a software repository exists on GitHub or a similar platform, everyone who wants to contribute has to hit the "fork" button, and start building their patches. As of this writing, docker on GitHub has 9860 forks, including ours. By this definition, however, all packages that distributions ship that include patches are forks. Red Hat ships the Linux Kernel, and I have not heard this referred to as a fork. *The docker upstream even relies on Ubuntu carrying patches for AUFS that were never merged into the upstream kernel.* Since Red Hat-based distributions don’t carry the AUFS patches, we contributed the support for Devicemapper, OverlayFS, and BTRFS backends, which are fully supported in the upstream kernel.  This is what enterprise distributions should do: attempt to ship packages configured in a way that they can be supported for a long time.
 
-At the end of the day, we continue to track the changes made to the upstream docker project and re-apply our patches to that project.  We believe this is an important distinction to allow freedom in software to thrive while continually building stronger communities.  It’s very different than a hostile fork which divides communities &mdash; we are still working very hard to maintain continuity around unified upstreams.
+At the end of the day, we continue to track the changes made to the upstream docker project and re-apply our patches to that project. We believe this is an important distinction to allow freedom in software to thrive while continually building stronger communities.  It’s very different than a hostile fork that divides communities&mdash;we are still working very hard to maintain continuity around unified upstreams.
 
-## How can I find out about patches for a particular version of docker?
+## How Can I Find Out About Patches for a Particular Version of docker?
 
-All of the patches that we ship are described in the README.md file on the appropriate branch of [our docker  repository](https://github.com/projectatomic/docker).  If you want to look at the patches for docker-1.12 you would look at [the docker-1.12 branch](https://github.com/projectatomic/docker/tree/docker-1.12).
+All of the patches we ship are described in the README.md file on the appropriate branch of [our docker  repository](https://github.com/projectatomic/docker). If you want to look at the patches for docker-1.12 you would look at [the docker-1.12 branch](https://github.com/projectatomic/docker/tree/docker-1.12).
 
 You can then look on the [docker patches list page](/docs/docker_patches) for information about these patches.
 
-## What kind of patches does Project Atomic include?
+## What Kind of Patches does Project Atomic Include?
+
+Here is a quick overview of our included patches.
 
 ### Upstream Fixes
 
-The upstream docker project tends to fix issues in the **next** version of docker. This means if a user finds an issue in docker-1.11 and we provide a fix for this to upstream, the patch gets merged in to the master branch, it will probably not get back ported to docker-1.11.  Since docker is releasing at such a rapid rate, they tell users to just install docker-1.12, when it is available.  This is fine for people who want to be on the bleeding edge, but in a lot of cases the newer version of docker comes with new issues along with the fixes. For example,  docker-1.11 split the docker daemon into three parts, docker daemon, containerd, and runc.  We did not feel this was stable enough to ship to enterprise customers right when it came out, yet it had multiple fixes for the docker-1.10 version.  Many users want to only get new fixes to their existing software and not have to re-certify their apps every 2 months.
+The upstream docker project tends to fix issues in the **next** version of docker. This means if a user finds an issue in docker-1.11 and we provide a fix for this to upstream, the patch gets merged in to the master branch, and it will probably not get back ported to docker-1.11. Since docker is releasing at such a rapid rate, they tell users to just install docker-1.12 when it is available. This is fine for people who want to be on the bleeding edge, but in a lot of cases the newer version of docker comes with new issues along with the fixes. For example, docker-1.11 split the docker daemon into three parts: docker daemon, containerd, and runc.  We did not feel this was stable enough to ship to enterprise customers right when it came out, yet it had multiple fixes for the docker-1.10 version. Many users want to only get new fixes to their existing software and not have to re-certify their apps every two months.
 
-Another issue with supporting stable software with rapidly changing dependencies is that developers on the stable projects must spend time ensuring that their product remains stable every time one of their dependencies is updated. This is an expensive process, dependencies end up being updated only infrequently.  This causes us to "cherry-pick" fixes from upstream docker and to ship these fixes on older versions so that we can get the benefits from the bug fixes without the cost of updating the entire dependency.  This is the same approach we take in order to add capabilities to the Linux kernel,  a practice that has proven to be very valuable to our users.
+Another issue with supporting stable software with rapidly changing dependencies is that developers on the stable projects must spend time ensuring that their product remains stable every time one of their dependencies is updated. This is an expensive process, dependencies end up being updated only infrequently. This causes us to "cherry-pick" fixes from upstream docker and to ship these fixes on older versions so that we can get the benefits from the bug fixes without the cost of updating the entire dependency. This is the same approach we take in order to add capabilities to the Linux kernel, a practice that has proven to be very valuable to our users.
 
-### Proposed patches for upstream
+### Proposed Patches for Upstream
 
-We carry patches that we know our users require right now, but have not yet been merged into the upstream project.  Every patch that we add to the Project Atomic repository also gets proposed to the upstream docker repository.  These sorts of patches remain on the Project Atomic repository briefly while they’re being considered upstream, or forever if the upstream community rejects them. If we don't agree with upstream docker and feel our users need these patches, we continue to carry them.  In some cases we have worked out alternative solutions like building authorization plugins.  For example, users of RHEL images are not supposed to push these image onto public web sites.  We wanted a way to prevent users from accidentally pushing RHEL based images to Docker Hub, so we originally created a patch to block the pushing.  When authorization plugins were added we then created a plugin to protect users from pushing RHEL content to a public registry like Docker Hub, and no longer had to carry the custom patch.
+We carry patches that we know our users require right now, but have not yet been merged into the upstream project.  Every patch that we add to the Project Atomic repository also gets proposed to the upstream docker repository. These sorts of patches remain on the Project Atomic repository briefly while they’re being considered upstream, or forever if the upstream community rejects them. If we don't agree with upstream docker and feel our users need these patches, we continue to carry them. In some cases we have worked out alternative solutions like building authorization plugins. 
+
+For example, users of RHEL images are not supposed to push these image onto public web sites. We wanted a way to prevent users from accidentally pushing RHEL based images to Docker Hub, so we originally created a patch to block the pushing.  When authorization plugins were added we then created a plugin to protect users from pushing RHEL content to a public registry like Docker Hub, and no longer had to carry the custom patch.
 
 ## Detailed List of Patches
 
-You can find the current table and list of patches on our new [docker patches list page](/docs/docker_patches)
+You can find the current table and list of patches on our new [docker patches list page](/docs/docker_patches).

--- a/source/blog/2016-08-18-docker-patches.html.md
+++ b/source/blog/2016-08-18-docker-patches.html.md
@@ -1,0 +1,48 @@
+---
+title: "Project Atomic Docker Patches"
+author: dwalsh
+date: 2016-08-16 12:00:00 UTC
+tags: docker, patches, development
+published: true
+comments: true
+---
+
+Project Atomic's version of the docker-based container runtime has been carrying a series of patches on the upstream docker project for a while now.  Each time we carry a patch it adds significant effort as we continue to track upstream, therefore we would prefer to never carry any patches.  We always strive to get our patches upstream and do it in the open.
+
+This post, and the accompanying document, will attempt to describe the patches we are currently carrying:
+
+* Explanation on types of patches
+* Description of patches
+* Links to GitHub discussions and pull requests for upstreaming the patches to docker.
+
+Some people have asserted that [our docker repo](https://github.com/projectatomic/docker) is a fork of the upstream docker project.
+
+##  What does it mean to be a fork?
+
+I have been in open source for a long time, and my definition of a "fork" might be dated.  I think of a "fork" as a hostile action taken by one group to get others to use and contribute to their version of an upstream project and ignore the "original" version.  For example LibreOffice forking off of OpenOffice or going way back Xorg forking off of Xfree86.
+
+Nowadays, GitHub has changed the meaning.  When a software repository exists on GitHub or similar, everyone who wants to contribute has to hit the "fork" button, and start building their patches.  As of this writing, docker on GitHub has 9860 forks, including ours.   By this definition, however, all packages that distributions ship that include patches are forks. Red Hat ships the Linux Kernel, and I have not heard this referred to as a fork. *The docker upstream even relies on Ubuntu carrying patches for AUFS that were never merged into the upstream kernel.*  Since Red Hat-based distributions don’t carry the AUFS patches, we contributed the support for Devicemapper, OverlayFS and BTRFS backends, that are fully supported in the upstream kernel.  This is what enterprise distributions should do: attempt to ship packages configured in a way that they can be supported for a long time.
+
+At the end of the day, we continue to track the changes made to the upstream docker project and re-apply our patches to that project.  We believe this is an important distinction to allow freedom in software to thrive while continually building stronger communities.  It’s very different than a hostile fork which divides communities &mdash; we are still working very hard to maintain continuity around unified upstreams.
+
+## How can I find out about patches for a particular version of docker?
+
+All of the patches that we ship are described in the README.md file on the appropriate branch of [our docker  repository](https://github.com/projectatomic/docker).  If you want to look at the patches for docker-1.12 you would look at [the docker-1.12 branch](https://github.com/projectatomic/docker/tree/docker-1.12).
+
+You can then look on the [docker patches list page](/docs/docker_patches) for information about these patches.
+
+## What kind of patches does Project Atomic include?
+
+### Upstream Fixes
+
+The upstream docker project tends to fix issues in the **next** version of docker. This means if a user finds an issue in docker-1.11 and we provide a fix for this to upstream, the patch gets merged in to the master branch, it will probably not get back ported to docker-1.11.  Since docker is releasing at such a rapid rate, they tell users to just install docker-1.12, when it is available.  This is fine for people who want to be on the bleeding edge, but in a lot of cases the newer version of docker comes with new issues along with the fixes. For example,  docker-1.11 split the docker daemon into three parts, docker daemon, containerd, and runc.  We did not feel this was stable enough to ship to enterprise customers right when it came out, yet it had multiple fixes for the docker-1.10 version.  Many users want to only get new fixes to their existing software and not have to re-certify their apps every 2 months.
+
+Another issue with supporting stable software with rapidly changing dependencies is that developers on the stable projects must spend time ensuring that their product remains stable every time one of their dependencies is updated. This is an expensive process, dependencies end up being updated only infrequently.  This causes us to "cherry-pick" fixes from upstream docker and to ship these fixes on older versions so that we can get the benefits from the bug fixes without the cost of updating the entire dependency.  This is the same approach we take in order to add capabilities to the Linux kernel,  a practice that has proven to be very valuable to our users.
+
+### Proposed patches for upstream
+
+We carry patches that we know our users require right now, but have not yet been merged into the upstream project.  Every patch that we add to the Project Atomic repository also gets proposed to the upstream docker repository.  These sorts of patches remain on the Project Atomic repository briefly while they’re being considered upstream, or forever if the upstream community rejects them. If we don't agree with upstream docker and feel our users need these patches, we continue to carry them.  In some cases we have worked out alternative solutions like building authorization plugins.  For example, users of RHEL images are not supposed to push these image onto public web sites.  We wanted a way to prevent users from accidentally pushing RHEL based images to Docker Hub, so we originally created a patch to block the pushing.  When authorization plugins were added we then created a plugin to protect users from pushing RHEL content to a public registry like Docker Hub, and no longer had to carry the custom patch.
+
+## Detailed List of Patches
+
+You can find the current table and list of patches on our new [docker patches list page](/docs/docker_patches)

--- a/source/docs/docker_patches.md
+++ b/source/docs/docker_patches.md
@@ -1,0 +1,156 @@
+---
+title: "Docker Patches"
+---
+
+# List of patches to Docker
+
+Project Atomic includes the development and maintenance of a number of patches to the docker daemon and related tools.
+
+All of the patches that we ship are described in the README.md file on the appropriate branch of [our docker  repository](https://github.com/projectatomic/docker).  If you want to look at the patches for docker-1.12 you would look at [the docker-1.12 branch](https://github.com/projectatomic/docker/tree/docker-1.12).
+
+Each time docker creates a new version, we create a new branch in projectatomic with the version name to match.  The current master is working on docker-1.13.  You can see the current patchset on [the 1.13 branch](https://github.com/projectatomic/docker/tree/docker-1.13).
+
+Patch types are:
+
+* Red Hat: support compatibility with Red Hat Enterprise Linux and related tools.
+* Upstream: Patches which were, or will be, submitted to mainstream docker.  Some have been rejected and are being maintained by the Atomic team.
+* Backports: Patches which backport fixes from later versions of docker to earlier ones.
+
+## Table of Patches
+
+| Name               | Type               | PRs           | Status                      |
+|--------------------|--------------------|---------------|-----------------------------|
+| Add-RHEL-super-secrets-patch | Red Hat | [6075](https://github.com/docker/docker/pull/6075) | Maintaining |
+| Add-add-registry-and-block-registry-options-to-docker | Upstream | [11991](https://github.com/docker/docker/pull/11991), [10411](https://github.com/docker/docker/pull/10411) | Rejected, Maintaining |
+| Improved-searching-experience | Upstream | | Rejected, Maintaining |
+| The-following-syscalls-should-not-be-blocked-by-seccomp | Upstream | [24221](https://github.com/docker/docker/pull/24221), [24510](https://github.com/docker/docker/pull/24510) | Rejected, Maintaining |
+| Add-dockerhooks-exec-custom-hooks-for-prestart/poststop-containers | Upstream | [17021](https://github.com/docker/docker/pull/17021) | Pending |
+| Return-rpm-version-of-packages-in-docker-version | Red Hat | [14591](https://github.com/docker/docker/pull/14591) | Maintaining |
+| rebase-distribution-specific-build | Upstream | [15364](https://github.com/docker/docker/pull/15364) | Pending |
+| System-logging-for-docker-daemon-API-calls | Upstream | [14446](https://github.com/docker/docker/pull/14446) | Blocked |
+| Audit-logging-support-for-daemon-API-calls | Upstream | [109](https://github.com/rhatdan/docker/pull/109) | Blocked |
+| Add-volume-support-to-docker-build | Upstream | See Below | See Below |
+
+## Longer Patch Descriptions
+
+Project Atomic is carrying a series of patches that we feel are required for our users or for our support engineering.
+
+### Add-RHEL-super-secrets-patch.patch
+
+This patch allows us to provide subscription management information from the host into containers for both `docker run` and `docker build`.  In order to get access to RHEL7 and RHEL6 content inside of a container via yum you need to use a subscription.  This patch allows the subscriptions to work inside the container.  The docker upstream thought this was too RHEL specific so told us to carry a patch.
+
+* [6075](https://github.com/docker/docker/pull/6075)
+
+Note: This is our oldest patch.  Other distributions, like [SuSe](https://github.com/SUSE/docker.mirror/commit/76a4eb2f2e79d1abec07dfe33cd99c3d7a4568c3),  are carrying similar patches to allow the hosts subscriptions to be used inside the container to update distribution specific content.
+
+### Add-add-registry-and-block-registry-options-to-docker.patch
+
+Users have been asking for us to provide a mechanism to allow additional registries to be specified in addition to docker.io.  We also want to have Red Hat Content available from our Registry by default. This patch allows users to customize the default registries available.  We believe this closely aligns with the way yum and apt currently work.  This patch also allows users to block images from registries.  Some users do not want software
+to be accidentally pulled and run on a machine.  Some users also have no access to the internet and want to setup private registries to handle their content.
+
+* [11991](https://github.com/docker/docker/pull/11991)
+* [10411](https://github.com/docker/docker/pull/10411)
+
+**Status**: Upstream docker does not like this patch set, because they want the **docker** experience to be the same everywhere.  If I do a `docker pull fedora`, I always get it from docker.io.  We and our customers do not agree, so we continue to carry this patch.  We prefer the yum/apt method for specifying registries.
+
+### Improved-searching-experience.patch
+
+Red Hat wants to allow users to search multiple registries as described above. This patch improves the search experience.
+
+**Status**:  This patch actually works with the Add-add-registry-and-block-registry-options-to-docke.patch so we need to carry it also.
+
+
+### The-following-syscalls-should-not-be-blocked-by-seccomp.patch
+
+Capabilities block these syscalls.
+
+`mount`, `umount2`, `unshare`, `reboot` and `name\_to\_handle\_at` are all needed to run `systemd` as PID 1 in a container. These syscalls work fine without administrator privileges, sys_admin disabled.  These syscalls also provide features that do not require administrative access.  Blocking them by default breaks known work loads for little added security. There is no easy way to discover which syscalls are blocked, so we noticed that users that needed this functionality would simply run their containers without *any* security by using `--privileged`. We feel that adding the capability for `systemd` to run as PID 1 in the container, thereby allowing our users to run with security enabled, far outweighs the negatives for allowing these syscalls with seccomp.
+
+With UserNamespace we want to allow users to potentially setup unshare additional namespaces.
+
+From `man 2 reboot`:
+...
+Behavior inside PID namespaces
+Since Linux 3.4, when reboot() is called from a PID namespace (see
+        pid_namespaces(7)) other than the initial PID namespace, the effect
+        of the call is to send a signal to the namespace "init" process.
+        LINUX_REBOOT_CMD_RESTART and LINUX_REBOOT_CMD_RESTART2 cause a SIGHUP
+        signal to be sent.  LINUX_REBOOT_CMD_POWER_OFF and
+        LINUX_REBOOT_CMD_HALT cause a SIGINT signal to be sent.
+
+* [21287](https://github.com/docker/docker/pull/21287)
+
+**Status**: docker upstream says that systemd inside of a container is not something they want to support, so they do not want this patch merged.  They also claim some of these syscalls open up security risks like allowing unshare(USERNS) to containers.  They have pointed out that this syscall is not blocked by SYS_ADMIN capability, which means it could potentially lead to a privilege escalation.  Since these syscalls are available to non privileged users on most distributions, it is not seen as a big security issue, and some just break functionality like reboot above.  There are lots of other syscalls that are required by admin privs that could be blocked but are not  because they would break common workloads.  There is little difference between that approach and our patch if systemd is to be considered a common workload. Blocking the unshare syscall can actually weaken security since a container process could tighten its security using this syscall, which is not prevented.
+
+We have a patch we are working with upstream docker to externalize the syscall whitelist file from the docker syscalls, this would allow distributions and admins to define their own list of syscalls to be used by default inside of containers. When this patch gets merged we can drop our patch and just ship distribution defaults.
+
+* [24221](https://github.com/docker/docker/pull/24221)
+* [24510](https://github.com/docker/docker/pull/24510)
+
+
+### Add-dockerhooks-exec-custom-hooks-for-prestart/poststop-containers.patch
+
+With the addition of runc/hooks support we want to add a feature to allow third parties to run helper programs before a docker container gets started and just after the container finishes.
+
+For example we want to add a RegisterMachine hook.
+
+For systems that support systemd/RegisterMachine, this hook would register a machine to the machinectl.  machinectl could then list docker containers along with other virtualization environments like kvm, and systemd-nspawn containers. Over time we would want to implement other machinectl features to get docker containers better integrated into the system.
+Another example of a hook  is a log agent that records when a container starts and stops and then sends a message to a monitoring station.
+
+Dockerhooks reads the `/usr/libexec/oci/hooks.d` directory to search for hooks, if the directory exists docker will execute the executables in this directory via runc/libcontainer is using PreStart and PostStop.  It will also send the config.json file as the second parameter.
+
+**Status**: We hope that the upstream docker will expose this feature just like it makes use of these hooks for setting up networking in containers.  So far they haven’t given users the option  to take advantage of these hooks.
+
+* [17021](https://github.com/docker/docker/pull/17021)
+
+### Return-rpm-version-of-packages-in-docker-version.patch
+
+Red Hat Support wants to know the version of the rpm package that docker is running.  This patch allows the distribution to show the rpm version of the client and server using the `docker version` command.  The docker upstream was not interested in this patch. This patch only affects the `docker info` command.
+
+* [14591](https://github.com/docker/docker/pull/14591)
+
+**Status**:   Since this is distribution specific, docker has rejected the patch. But it is required for our support people to easily identify the client and server RPM of the patches in use, so we plan on carrying it.  This patch is also easy to maintain.
+
+### rebase-distribution-specific-build.patch
+
+Current upstream docker tests run totally on Debian.  We want to be able to make sure all tests run on platforms and containers we support.  This patch allows us to run distribution specific tests. This means that `make test` on RHEL7 will use RHEL7-based images for the test, and `make test` on Fedora will use Fedora-based images for the test.  The docker upstream was not crazy about the substitutions done in this patch, and the changes never show up in the version of the docker client/daemon that we ship.
+
+* [15364](https://github.com/docker/docker/pull/15364)
+
+**Status**: Up til now upstream docker does not like the way this works, not sure if there is a good way forward.   This patch set is really only for QA and does not change the way that docker works.
+
+### System-logging-for-docker-daemon-API-calls.patch
+
+Red Hat wants to log all access to the docker daemon.  This patch records all access to the docker daemon in syslog/journald.  Currently docker logs access in its event logs but these logs are not stored permanently and do not record critical information like loginuid to record which user created/started/stopped containers.  We will continue to work with the docker upstream to get this patch merged. The docker upstream indicates that they want to wait until the authentication patches get merged.
+
+* [14446](https://github.com/docker/docker/pull/14446)
+
+**Status**:  This patch is currently blocked because the docker CLI does not have anyway of authenticating the user doing the activity.  All docker currently logs when an activity happens is something like **root** started a container.  With this patch, we can actually log that **dwalsh** started a container, but this only works for local domain socket clients.  We are working with upstream on an [authentication patch](https://github.com/docker/docker/pull/20883) that can identify the user on the client initiating the action.  When/If that patch gets merged we will resubmit and attempt to get this patch merged.
+
+### Audit-logging-support-for-daemon-API-calls.patch
+
+This is a follow on patch to the previous syslog patch, to record all auditable events to the audit log.  We want to get `docker daemon` to some level of common criteria.  In order to do this administrator activity must be audited.
+
+* [109](https://github.com/rhatdan/docker/pull/109)
+
+**Status**: Similar to the System Logging patch, we need to wait for authentication patch gets merged before working this into docker upstream.
+
+### Add-volume-support-to-docker-build.patch
+
+This patch adds the ability to add bind mounts at build-time. This will be helpful in supporting builds with host files and secrets. The `--volume|-v flag` is added for this purpose. Trying to define a volume (ala docker run) errors out. Each bind mounts' mode will be read-only and it will preserve any SELinux label which was defined via the cli (`:[z,Z]`). Defining a read-write mode (`:rw`) will just print a warning in the build output and the actual mode will be
+changed to read-only.
+
+**Status**: Upstream docker has continuously blocked all efforts to support volumes in `docker build`.
+
+These 2 below are open but no progress so far in years:
+
+* [18603](* [18603](https://github.com/docker/docker/issues/18603))
+* [14080](* [14080](https://github.com/docker/docker/issues/14080))
+
+Closed proposals:
+
+* [3949](* [3949](https://github.com/docker/docker/issues/3949))
+* [3156](* [3156](https://github.com/docker/docker/issues/3156))
+* [14251](* [14251](https://github.com/docker/docker/issues/14251))
+
+Up until now no satisfactory alternatives have arrived, but there are several projects working to build container images outside of docker, including [Ansible](http://docs.ansible.com/ansible/docker_image_module.html) and potentially [dockerramp](https://github.com/jlhawn/dockramp).

--- a/source/docs/docker_patches.md
+++ b/source/docs/docker_patches.md
@@ -14,7 +14,7 @@ Patch types are:
 
 * Red Hat: support compatibility with Red Hat Enterprise Linux and related tools.
 * Upstream: Patches which were, or will be, submitted to mainstream docker.  Some have been rejected and are being maintained by the Atomic team.
-* Backports: Patches which backport fixes from later versions of docker to earlier ones.
+* Backports: Patches which backport fixes from later versions of docker to earlier ones.  
 
 ## Table of Patches
 
@@ -30,6 +30,10 @@ Patch types are:
 | System-logging-for-docker-daemon-API-calls | Upstream | [14446](https://github.com/docker/docker/pull/14446) | Blocked |
 | Audit-logging-support-for-daemon-API-calls | Upstream | [109](https://github.com/rhatdan/docker/pull/109) | Blocked |
 | Add-volume-support-to-docker-build | Upstream | See Below | See Below |
+
+Patches which have been accepted by upstream docker are not represented in this chart.
+
+A list of backport patches will be added to this page later.
 
 ## Longer Patch Descriptions
 


### PR DESCRIPTION
This contains Dan's post on Docker patches, as well as a visually organized table of patches we maintain.

@rhatdan, questions:

1. Your blog post mentions backporting fixes, but none of the listed patches are of that type.
2. Is there a PR or Issue for Improved-searching-experience?
3. If you can build the site, please check out the new docker_patches doc I created to see if that works for you.

@bproffitt, I took one pass at editing this, but it's a LOT of text.  Please look for basic spelling/grammar issues I might have missed?