### PR TITLE
Revert removing `ServiceAccount` from admission control

### DIFF
--- a/source/docs/gettingstarted.md
+++ b/source/docs/gettingstarted.md
@@ -121,11 +121,6 @@ The apiserver needs to be set to listen on all IP addresses, instead of just loc
     # The address on the local server to listen to.
     KUBE_API_ADDRESS="--address=0.0.0.0"
 
-If you follow this guide on a test cluster, you will also need to remove `ServiceAccount` from the `KUBE_ADMISSION_CONTROL` parameter. The complete line will look like:
-
-    KUBE_ADMISSION_CONTROL="--admission_control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ResourceQuota"
-
-
 
  If you need to modify the set of IPs that Kubernetes assigns to services, change the KUBE_SERVICE_ADDRESSES value. Since this guide is using the 192.168.122.0/24 and 172.16.0.0/12 networks, we can leave the default.  This address space needs to be unused elsewhere, but doesn't need to be reachable from either of the other networks.
 


### PR DESCRIPTION
I kept it and it worked. There is no value from removing it.

If you believe otherwise, please at least tell us why we need to remove it.