### PR TITLE
blog:  fix CRI-O video embed

### DIFF
--- a/source/blog/2017-02-08-crio-runtimes.html.md
+++ b/source/blog/2017-02-08-crio-runtimes.html.md
@@ -27,4 +27,4 @@ We worked with Intel engineers to give their OCI container runtime, [Clear Conta
 
 We're excited to have CRI-O and Clear Containers running together. I have created a small demo of this integration to show how the kubelet is seamlessly running pods with Clear Containers underneath:
 
-<iframe width="960" height="720" src="https://www.youtube.com/watch?v=gEBSCesjkvA?rel=0" frameborder="0" allowfullscreen></iframe>
+<iframe width="915" height="480" src="https://www.youtube.com/embed/gEBSCesjkvA" frameborder="0"></iframe>


### PR DESCRIPTION
The embedded video wasn't loading for me using FF51.  The dev console
showed the following error:

`Load denied by X-Frame-Options:
https://www.youtube.com/watch?v=gEBSCesjkvA does not permit
cross-origin framing.`

After some hunting around via Google, I found that the URL of the
video had be tweaked slightly to avoid the issue.  Additionally, I
resized the iframe to fit within the body of the post.