### PR TITLE
blog: short post on switching to overlay2 driver

### DIFF
--- a/source/blog/2017-03-29-migrate-fedora-atomic-host-to-overlay2.md
+++ b/source/blog/2017-03-29-migrate-fedora-atomic-host-to-overlay2.md
@@ -10,7 +10,7 @@ tags: atomic, fedora, docker, overlay2
 On the [Project Atomic mailing list](https://lists.projectatomic.io/projectatomic-archives/atomic/2017-March/msg00015.html), [Colin Walters](https://twitter.com/cgwalters) posted
 a quick set of instructions on how to migrate the Docker storage driver from `devicemapper` to `overlay2` on Fedora Atomic Host.
 
-The `overlay2` driver will be the default storage driver in Fedora 26, so making this change will give you a chance to test out your workloads
+The `overlay2` driver will be the [default storage driver in Fedora 26](https://fedoraproject.org/wiki/Changes/DockerOverlay2), so making this change will give you a chance to test out your workloads
 before the Fedora 26 release.
 
 Colin noted that the folks working on the `atomic` CLI are developing a way to [migrate all of your images and containers](https://trello.com/c/vAunYr5K/310-docker-storage-migrate-images-containers-when-switching-drivers) when you want to switch storage drivers.  Until that work is complete, the only way to switch drivers is destructive and results in a loss of your images and containers.

--- a/source/blog/2017-03-29-migrate-fedora-atomic-host-to-overlay2.md
+++ b/source/blog/2017-03-29-migrate-fedora-atomic-host-to-overlay2.md
@@ -13,13 +13,31 @@ a quick set of instructions on how to migrate the Docker storage driver from `de
 The `overlay2` driver will be the default storage driver in Fedora 26, so making this change will give you a chance to test out your workloads
 before the Fedora 26 release.
 
+Colin noted that the folks working on the `atomic` CLI are developing a way to [migrate all of your images and containers](https://trello.com/c/vAunYr5K/310-docker-storage-migrate-images-containers-when-switching-drivers) when you want to switch storage drivers.  Until that work is complete, the only way to switch drivers is destructive and results in a loss of your images and containers.
+
+Instead of using the raw commands noted in the email, we can do much of the same thing using the `atomic` CLI.
+
 **WARNING** These steps should only be performed if you understand that this will destroy all of your containers, images, and volumes.
+
+```
+$ systemctl stop docker
+$ atomic storage reset
+  # Reallocate space to the root VG - tweak how much to your liking
+$ lvm lvextend -r -l +50%FREE atomicos/root
+  # Note, this 'atomic modify' command is currently broken in Fedora 25 Atomic Host (See https://bugzilla.redhat.com/show_bug.cgi?id=1437136)
+$ atomic storage modify --driver overlay2
+$ systemctl start docker
+```
+
+READMORE
+
+If you want to perform the migration without using the `atomic` CLI, you can use the raw commands.
 
 ```
 $ systemctl stop docker
 $ rm /var/lib/docker/* -rf
 $ lvm lvremove atomicos/docker-pool
-  # Reallocate space to the root VG - tweak how much to your liking
+  # Reallocate space to the root - tweak how much to your liking
 $ lvm lvextend -r -l +50%FREE atomicos/root
 $ echo STORAGE_DRIVER=overlay2 >> /etc/sysconfig/docker-storage-setup
 $ rm /etc/sysconfig/docker-storage

--- a/source/blog/2017-03-29-migrate-fedora-atomic-host-to-overlay2.md
+++ b/source/blog/2017-03-29-migrate-fedora-atomic-host-to-overlay2.md
@@ -1,0 +1,27 @@
+---
+title: Migrating the Docker Storage Driver to overlay2
+author: miabbott
+date: 2017-03-29 16:00:00 UTC
+published: true
+comments: true
+tags: atomic, fedora, docker, overlay2
+---
+
+On the [Project Atomic mailing list](https://lists.projectatomic.io/projectatomic-archives/atomic/2017-March/msg00015.html), [Colin Walters](https://twitter.com/cgwalters) posted
+a quick set of instructions on how to migrate the Docker storage driver from `devicemapper` to `overlay2` on Fedora Atomic Host.
+
+The `overlay2` driver will be the default storage driver in Fedora 26, so making this change will give you a chance to test out your workloads
+before the Fedora 26 release.
+
+**WARNING** These steps should only be performed if you understand that this will destroy all of your containers, images, and volumes.
+
+```
+$ systemctl stop docker
+$ rm /var/lib/docker/* -rf
+$ lvm lvremove atomicos/docker-pool
+  # Reallocate space to the root VG - tweak how much to your liking
+$ lvm lvextend -r -l +50%FREE atomicos/root
+$ echo STORAGE_DRIVER=overlay2 >> /etc/sysconfig/docker-storage-setup
+$ rm /etc/sysconfig/docker-storage
+$ systemctl start docker
+```

--- a/source/blog/2017-05-04-migrate-fedora-atomic-host-to-overlay2.md
+++ b/source/blog/2017-05-04-migrate-fedora-atomic-host-to-overlay2.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating the Docker Storage Driver to overlay2
 author: miabbott
-date: 2017-03-29 16:00:00 UTC
+date: 2017-05-04 16:00:00 UTC
 published: true
 comments: true
 tags: atomic, fedora, docker, overlay2
@@ -15,7 +15,7 @@ before the Fedora 26 release.
 
 Colin noted that the folks working on the `atomic` CLI are developing a way to [migrate all of your images and containers](https://trello.com/c/vAunYr5K/310-docker-storage-migrate-images-containers-when-switching-drivers) when you want to switch storage drivers.  Until that work is complete, the only way to switch drivers is destructive and results in a loss of your images and containers.
 
-Instead of using the raw commands noted in the email, we can do much of the same thing using the `atomic` CLI.
+Instead of using the raw commands noted in the email, we can do much of the same thing using the `atomic` CLI.  You'll need to have `atomic-1.17.1-2` or later for the the following `atomic` commands to work successfully.
 
 **WARNING** These steps should only be performed if you understand that this will destroy all of your containers, images, and volumes.
 
@@ -24,7 +24,6 @@ $ systemctl stop docker
 $ atomic storage reset
   # Reallocate space to the root VG - tweak how much to your liking
 $ lvm lvextend -r -l +50%FREE atomicos/root
-  # Note, this 'atomic modify' command is currently broken in Fedora 25 Atomic Host (See https://bugzilla.redhat.com/show_bug.cgi?id=1437136)
 $ atomic storage modify --driver overlay2
 $ systemctl start docker
 ```


### PR DESCRIPTION
@cgwalters posted an informative message to the mailing list about
migrating to `overlay2` from `devicemapper`.  I thought it would be
good to put it on the blog for additional visibility.