### PR TITLE
blog: rpm-ostree v2017.5 released

### DIFF
--- a/source/blog/2017-04-29-rpm-ostree-v2017.5-released.html.md
+++ b/source/blog/2017-04-29-rpm-ostree-v2017.5-released.html.md
@@ -1,0 +1,76 @@
+---
+title: rpm-ostree v2017.5 released
+author: jlebon
+date: 2017-04-29 18:00:00 UTC
+tags: rpm-ostree, rpm, ostree, atomic, atomic host
+comments: true
+published: true
+---
+
+[rpm-ostree](https://rpm-ostree.readthedocs.org/) is the
+hybrid image/package system that provides transactional
+upgrades on Atomic Host. Here are some highlights from
+version
+[v2017.5](https://github.com/projectatomic/rpm-ostree/releases/tag/v2017.5).
+
+READMORE
+
+This is a short release with mostly bugfixes, though there
+are some small visible changes. You can test it out by
+[rebasing your Fedora Atomic Host](https://fedoraproject.org/wiki/QA:Updates_Testing#Using_it_with_Atomic_Host_.28Fedora_24_and_later.29)
+onto the testing branch. Feel free to also leave karma in
+the pending Bodhi updates:
+
+- [Fedora 25 update](https://bodhi.fedoraproject.org/updates/FEDORA-2017-2fa9ff86ba)
+- [Fedora 26 update](https://bodhi.fedoraproject.org/updates/FEDORA-2017-c5b64407b6)
+
+### More terse status output by default
+
+In v2017.4, we slightly changed the output of the `status`
+command so that the `Commit` line was hidden when packages
+are layered:
+
+```
+# rpm-ostree status
+State: idle
+Deployments:
+* fedora-atomic:fedora-atomic/25/x86_64/docker-host
+             Version: 25.113 (2017-04-25 01:47:29)
+          BaseCommit: 3492546bc1ef6bca1bc7801ed6bb0414f90cc96668e067996dba3dee0d83e6c3
+              OSName: fedora-atomic
+     LayeredPackages: ltrace
+```
+
+The rationale is that the `Commit` line in this context is
+specific to this host and has much less value than the
+`BaseCommit`, which is the actual ostree commit published by
+Fedora.
+
+In v2017.5, the `OSName` line is also no longer printed by
+default. Essentially, for the great majority of Atomic Host
+users, it is superfluous information. You can read more
+about this change
+[here](https://github.com/projectatomic/rpm-ostree/pull/743).
+
+However, the `status` command did learn a `--verbose` switch
+to force it to print both the `Commit` and the `OSName`
+(which was renamed to `StateRoot`):
+
+```
+# rpm-ostree status
+State: idle
+Deployments:
+* jlebon:fedora-atomic/25/x86_64/docker-host
+             Version: 25.113.modified (2017-04-25 01:47:29)
+          BaseCommit: 3492546bc1ef6bca1bc7801ed6bb0414f90cc96668e067996dba3dee0d83e6c3
+     LayeredPackages: ltrace
+# rpm-ostree status --verbose
+State: idle
+Deployments:
+* jlebon:fedora-atomic/25/x86_64/docker-host
+             Version: 25.113.modified (2017-04-25 01:47:29)
+          BaseCommit: 3492546bc1ef6bca1bc7801ed6bb0414f90cc96668e067996dba3dee0d83e6c3
+              Commit: 4a926bfaa84b3307577b2ef6673cf2079f7373ebe2219cd7c2e30d75e7a2584b
+           StateRoot: fedora-atomic
+     LayeredPackages: ltrace
+```


### PR DESCRIPTION
I dated this Apr 29th, to give the testing branch time to compose.