### PR TITLE
Possible wrong master KUBE_API port in docs

### DIFF
--- a/source/docs/gettingstarted.md
+++ b/source/docs/gettingstarted.md
@@ -146,7 +146,7 @@ We'll be setting up the etcd store that Kubernetes will use.  We're using a sing
     KUBE_ETCD_SERVERS="--etcd_servers=http://192.168.122.10:2379"
 
     # How the controller-manager, scheduler, and proxy find the kube-apiserver
-    KUBE_MASTER="--master=http://192.168.122.10:443"
+    KUBE_MASTER="--master=http://192.168.122.10:8080"
 
 #### Apiserver service configuration
 The apiserver needs to be set to listen on all IP addresses, instead of just localhost.


### PR DESCRIPTION
Hello,

I was trying to use the Atomic Getting Started Guide to setup Kubernetes on top of CentOS (non-Atomic), and lost about 2 hours trying to figure out why it didn't work initially.

So I found this configuration in Kube Master API section causing the error, and fixed it in my env changing it to port 8080.

Maybe my assumption is wrong, since this tutorial is for Fedora 25, but probably many others could face this problem described here.

Thanks!