### PR TITLE
Dockerfile: use RUN label to make re-running easier

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -53,9 +53,13 @@ root directory, run the docker build:
 
 If your local machine has Docker secured, then you'll need to sudo the above command.
 
+This will build the container image `middleman` and then run it using
+`atomic run middleman`.
+
 Once the container is up and running, the site will be available on [127.0.0.1:4567](http://127.0.0.1:4567).
 
-Note that `docker.sh` builds the site's image every time it runs due to cache issues. This may take a significant amount of time on slower machines.
+To restart the container at a later time, you can simply do `atomic run middleman` or if
+you'd like to rebuild the container, `docker.sh`.
 
 ## Manual Build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,8 @@ RUN bundle install
 EXPOSE 4567
 ENTRYPOINT [ "bundle", "exec" ]
 CMD [ "middleman", "server" ]
+
+LABEL RUN="/usr/bin/docker run --rm -ti -p 4567:4567 \
+             -v \"\$PWD/source:/tmp/source:ro\" \
+             -v \"\$PWD/data:/tmp/data\" \
+             \${IMAGE}"

--- a/docker.sh
+++ b/docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# install everything in a docker container based on Fedora 22
+# install everything in a docker container based on Fedora 25
 # permit to have the same env on any system without any issue
 
 # set SElinux context to allow docker to read the source directory
@@ -8,4 +8,4 @@ chcon -Rt svirt_sandbox_file_t data/
 
 # requires docker and being in the right group
 docker build -t middleman .
-docker run --rm -p 4567:4567 -v "$(pwd)"/source:/tmp/source:ro -v "$(pwd)"/data:/tmp/data middleman
+atomic run middleman


### PR DESCRIPTION
Add a `RUN` label and make `docker.sh` use `atomic run`. This makes it
easier for humans to rerun middleman without having to rebuild the
image everytime.