### PR TITLE
Remove invalid root access reference

### DIFF
--- a/source/blog/2017-06-22-introducing-buildah.html.md
+++ b/source/blog/2017-06-22-introducing-buildah.html.md
@@ -92,7 +92,7 @@ Unit docker.service could not be found.
 #
 ```
 
-We don't need any other container runtime, either. By not installing Docker or another container runtime we save file system space and lessen both memory usage and CPU processing time on the system. The daemons associated with those runtimes are not only not running, they're not even present. As we'll see in a future blog, Buildah also allows you to build smaller containers than Docker does. In addition to these advantages, Buildah is easily embeddable in automation scripts and inside other container-building tools, since neither a server process nor root access are required.
+We don't need any other container runtime, either. By not installing Docker or another container runtime we save file system space and lessen both memory usage and CPU processing time on the system. The daemons associated with those runtimes are not only not running, they're not even present. As we'll see in a future blog, Buildah also allows you to build smaller containers than Docker does. In addition to these advantages, Buildah is easily embeddable in automation scripts and inside other container-building tools as a server process is not required.
 
 ## Manipulating the Image
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

The last bit of the diff below we used to say 

"container-building tools, since neither a server process nor root access are required."

However root access is required.  I've reworded this to: 

"container-building tools as a server process is not required.".