### PR TITLE
fix bwrap-oci link

### DIFF
--- a/source/blog/2017-07-14-unprivileged-containers-with-bwrap-oci-and-bubblewrap.md
+++ b/source/blog/2017-07-14-unprivileged-containers-with-bwrap-oci-and-bubblewrap.md
@@ -35,8 +35,8 @@ If you'd like to try the demo out, you’ll need to build the
 development version for both of them.  You can get the last source
 from the git repos here:
 
-- [bubblewrap](https://github.com/projectatomic/bubblewrap.git)
-- [bwrap-oci](git@github.com:projectatomic/bwrap-oci.git)
+- [bubblewrap](https://github.com/projectatomic/bubblewrap)
+- [bwrap-oci](https://github.com/projectatomic/bwrap-oci)
 
 You can install the needed libraries with `sudo dnf build bubblewrap
 bwrap-oci`.


### PR DESCRIPTION
The original bwrap-oci link gets incorrectly converted to
<https://www.projectatomic.io/blog/2017/07/unprivileged-containers-with-bwrap-oci-and-bubblewrap/git@github.com:.gitb>
