### PR TITLE
Replaced two links with a link to Container Best Practices that obsol…

### DIFF
--- a/source/docs/index.html.haml
+++ b/source/docs/index.html.haml
@@ -75,14 +75,11 @@ title: Project Atomic Documentation
     %h3 Building New Images
 
     %p
-      The
-      %a( href="/docs/docker-building-images" ) Building Docker Images
-      provides guidelines on how to build new Docker images for your
-      application deployments, and the
-      %a( href="/docs/docker-image-author-guidance" ) Docker Image Author Guidance
-      gives a set of explanations and tips which will help authoring new
-      Docker images.
-
+      Through a set of recommendations,
+      %a( href="http://docs.projectatomic.io/container-best-practices/)
+      Container Best Practices provides comprehensive guidance to planning,
+      creation and building of Docker images for your application
+      deployments.
 
   .col-md-4.col-sm-12
     %h3 Containment and Security


### PR DESCRIPTION
The Container Best Practices project started as part of Project Atomic, but I couldn't find it linked from the site anywhere. I believe the document obsoletes a few sections that are under docs on the site (at minimum Building docker images and Author guidance), but I didn't want to make any bigger removals for now.