### PR TITLE
Fix Link to Container Best Practices on Docs index

### DIFF
--- a/source/docs/index.html.haml
+++ b/source/docs/index.html.haml
@@ -76,8 +76,8 @@ title: Project Atomic Documentation
 
     %p
       Through a set of recommendations,
-      %a( href="http://docs.projectatomic.io/container-best-practices/")
-      Container Best Practices provides comprehensive guidance to planning,
+      %a( href="http://docs.projectatomic.io/container-best-practices/") Container Best Practices
+      provides comprehensive guidance to planning,
       creation and building of Docker images for your application
       deployments.
 


### PR DESCRIPTION
Link should now be visible.