### PR TITLE
post on migrating kube on f27

### DIFF
--- a/source/blog/2017-11-08-migrating-kubernetes-on-fedora-atomic-host-27.html.md
+++ b/source/blog/2017-11-08-migrating-kubernetes-on-fedora-atomic-host-27.html.md
@@ -1,0 +1,104 @@
+---
+title: Migrating Kubernetes on Fedora Atomic Host 27
+author: jbrooks
+date: 2017-11-08 21:43:56 UTC
+tags: atomic, kubernetes, fedora, system containers, rpm-ostree
+comments: true
+published: true
+---
+
+Starting with version 27 of Fedora Atomic Host, the rpms for Kubernetes, Flannel and Etcd are no longer baked into the host's image, but are installable instead either as [system containers](http://www.projectatomic.io/blog/2016/09/intro-to-system-containers/) or via [package layering](https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/#hybrid-imagepackaging-via-package-layering).
+
+System containers can serve as drop-in replacements for components that had been included in the Fedora Atomic image. Once installed, these components will be manageable using the same systemctl commands that apply to regular rpm-installed components. System containers are very flexible -- you can easily run system container images based on CentOS or on older (or newer) versions of Fedora on a Fedora Atomic 27 host.
+
+Package layering makes it possible to install regular rpm packages from configured repositories. These additional "layered" packages are persistent across upgrades, rebases, and deploys. You must typically reboot after layering on packages, and not all packages may be installed in this way. For instance, rpms that install content to `/opt` aren't currently installable via package layering. Unlike with system containers, the packages you layer onto your host must be compatible with the version of Fedora the host is running.
+
+I've you're running a Kubernetes cluster on Fedora Atomic Host that depends on the baked in versions of these components, such as a cluster installed via the Ansible scripts in the [kubernetes/contrib repo](https://github.com/kubernetes/contrib/tree/master/ansible), you'll need to choose one of these methods to migrate your cluster when [upgrading to Fedora Atomic 27](TK LINK to Fedora upgrade post).
+
+## Migrating Kubernetes and related components using System Containers
+
+To replace Kubernetes, Flannel and Etcd with system containers, you would run the following commands. You could run these commands on a Fedora Atomic 26 host, [upgrade to 27](TK LINK to Fedora upgrade post), and, upon rebooting, your components and any cluster based on them should be up and running. 
+
+### System containers for master nodes
+
+```bash
+# atomic install --system --system-package=no --name kube-apiserver registry.fedoraproject.org/f27/kubernetes-apiserver
+
+# atomic install --system --system-package=no --name kube-controller-manager registry.fedoraproject.org/f27/kubernetes-controller-manager
+
+# atomic install --system --system-package=no --name kube-scheduler registry.fedoraproject.org/f27/kubernetes-scheduler
+```
+
+Note: the kube-apiserver system container provides the `kubectl` client.
+
+
+### System containers for worker nodes
+
+```bash
+# atomic install --system --system-package=no --name kubelet registry.fedoraproject.org/f27/kubernetes-kubelet
+
+# atomic install --system --system-package=no --name kube-proxy registry.fedoraproject.org/f27/kubernetes-proxy
+```
+
+### System container for etcd
+
+```bash
+# atomic install --system --system-package=no --name etcd registry.fedoraproject.org/f27/etcd
+```
+
+When installed with the name "etcd," the etcd system container expects to find stores etcd data in `/var/lib/etcd/etcd.etcd`. The etcd rpm is configured by default to store data in `/var/lib/etcd/default.etcd`, and the ansible scripts in [kubernetes/contrib](https://github.com/kubernetes/contrib/tree/master/ansible) use `/var/lib/etcd`. On a system running etcd as configured by the kubernetes/contrib ansible scripts, you'd move your data as follows:
+
+```bash
+# systemctl stop etcd
+
+# cp -r /var/lib/etcd/member /var/lib/etcd/etcd.etcd/
+```
+
+Note: the etcd container provides the `etcdctl` client.
+
+### System container for flannel
+
+```bash
+# atomic install --system --system-package=no --name flanneld registry.fedoraproject.org/f27/flannel
+```
+
+### Updating system containers
+
+System container updates are independent of host updates. You can update a system container by pulling an updated version of the image, and then running the `atomic containers update` command.
+
+```
+# atomic pull registry.fedoraproject.org/f27/etcd
+# atomic containers update etcd
+```
+
+ You can then roll back to the previous system container version by running `atomic containers rollback`.
+ 
+ ```
+ # atomic containers rollback etcd
+ ```
+
+## Migrating Kubernetes and related components using Package Layering
+
+You won't be able to layer new package versions on until the existing ones are removed during the [upgrade to 27](TK LINK to Fedora upgrade post).  Upon rebooting in to 27, you can run the following commands to replace Kubernetes, Flannel and Etcd with package layering. after which your components and any cluster based on them should be up and running. 
+
+### Package layering on master nodes
+
+```bash
+# rpm-ostree install kubernetes-master flannel -r
+```
+
+### Package layering on worker nodes
+
+```bash
+# rpm-ostree install kubernetes-node flannel -r
+```
+
+### Package layering for etcd
+
+```bash
+# rpm-ostree install etcd -r
+```
+
+## Updating package layers
+
+During regular rpm-ostree upgrades (with `rpm-ostree upgrade` or `atomic host upgrade`), your host will fetch updated package versions from your configured repositories.

--- a/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
+++ b/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
@@ -1,7 +1,7 @@
 ---
 title: Migrating Kubernetes on Fedora Atomic Host 27
 author: jbrooks
-date: 2017-11-08 21:43:56 UTC
+date: 2017-11-15 00:00:00 UTC
 tags: atomic, kubernetes, fedora, system containers, rpm-ostree
 comments: true
 published: true
@@ -13,11 +13,11 @@ System containers can serve as drop-in replacements for components that had been
 
 Package layering makes it possible to install regular rpm packages from configured repositories. These additional "layered" packages are persistent across upgrades, rebases, and deploys. You must typically reboot after layering on packages, and not all packages may be installed in this way. For instance, rpms that install content to `/opt` aren't currently installable via package layering. Unlike with system containers, the packages you layer onto your host must be compatible with the version of Fedora the host is running.
 
-I've you're running a Kubernetes cluster on Fedora Atomic Host that depends on the baked in versions of these components, such as a cluster installed via the Ansible scripts in the [kubernetes/contrib repo](https://github.com/kubernetes/contrib/tree/master/ansible), you'll need to choose one of these methods to migrate your cluster when [upgrading to Fedora Atomic 27](TK LINK to Fedora upgrade post).
+I've you're running a Kubernetes cluster on Fedora Atomic Host that depends on the baked in versions of these components, such as a cluster installed via the Ansible scripts in the [kubernetes/contrib repo](https://github.com/kubernetes/contrib/tree/master/ansible), you'll need to choose one of these methods to migrate your cluster when [upgrading to Fedora Atomic 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/).
 
 ## Migrating Kubernetes and related components using System Containers
 
-To replace Kubernetes, Flannel and Etcd with system containers, you would run the following commands. You could run these commands on a Fedora Atomic 26 host, [upgrade to 27](TK LINK to Fedora upgrade post), and, upon rebooting, your components and any cluster based on them should be up and running. 
+To replace Kubernetes, Flannel and Etcd with system containers, you would run the following commands. You could run these commands on a Fedora Atomic 26 host, [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/), and, upon rebooting, your components and any cluster based on them should be up and running. 
 
 ### System containers for master nodes
 
@@ -43,7 +43,7 @@ Note: the kube-apiserver system container provides the `kubectl` client.
 ### System container for etcd
 
 ```bash
-# atomic install --system --system-package=no --name etcd registry.fedoraproject.org/f27/etcd
+# atomic install --system --system-package=no --storage=ostree --name etcd registry.fedoraproject.org/f27/etcd
 ```
 
 When installed with the name "etcd," the etcd system container expects to find stores etcd data in `/var/lib/etcd/etcd.etcd`. The etcd rpm is configured by default to store data in `/var/lib/etcd/default.etcd`, and the ansible scripts in [kubernetes/contrib](https://github.com/kubernetes/contrib/tree/master/ansible) use `/var/lib/etcd`. On a system running etcd as configured by the kubernetes/contrib ansible scripts, you'd move your data as follows:
@@ -79,7 +79,7 @@ System container updates are independent of host updates. You can update a syste
 
 ## Migrating Kubernetes and related components using Package Layering
 
-You won't be able to layer new package versions on until the existing ones are removed during the [upgrade to 27](TK LINK to Fedora upgrade post).  Upon rebooting in to 27, you can run the following commands to replace Kubernetes, Flannel and Etcd with package layering. after which your components and any cluster based on them should be up and running. 
+You won't be able to layer new package versions on until the existing ones are removed during the [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/).  Upon rebooting in to 27, you can run the following commands to replace Kubernetes, Flannel and Etcd with package layering. after which your components and any cluster based on them should be up and running. 
 
 ### Package layering on master nodes
 

--- a/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
+++ b/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
@@ -79,24 +79,18 @@ System container updates are independent of host updates. You can update a syste
 
 ## Migrating Kubernetes and related components using Package Layering
 
-You won't be able to layer new package versions on until the existing ones are removed during the [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/).  Upon rebooting in to 27, you can run the following commands to replace Kubernetes, Flannel and Etcd with package layering. after which your components and any cluster based on them should be up and running. 
+During the [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/), you can opt to layer on particular packages by appending `--install PACKAGE` to the `rpm-ostree rebase` commands. Upon rebooting into 27, your components and any cluster based on them should be up and running. 
 
-### Package layering on master nodes
+### Package layering on master + etcd nodes
 
 ```bash
-# rpm-ostree install kubernetes-master flannel -r
+# rpm-ostree rebase fedora-atomic-27:fedora/27/x86_64/atomic-host --install kubernetes-master --install flannel --install etcd -r
 ```
 
 ### Package layering on worker nodes
 
 ```bash
-# rpm-ostree install kubernetes-node flannel -r
-```
-
-### Package layering for etcd
-
-```bash
-# rpm-ostree install etcd -r
+# rpm-ostree rebase fedora-atomic-27:fedora/27/x86_64/atomic-host --install kubernetes-node --install flannel -r
 ```
 
 ## Updating package layers

--- a/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
+++ b/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
@@ -7,17 +7,17 @@ comments: true
 published: true
 ---
 
-Starting with version 27 of Fedora Atomic Host, the rpms for Kubernetes, Flannel and Etcd are no longer baked into the host's image, but are installable instead either as [system containers](http://www.projectatomic.io/blog/2016/09/intro-to-system-containers/) or via [package layering](https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/#hybrid-imagepackaging-via-package-layering).
+Starting with Fedora 27 Atomic Host, the rpms for Kubernetes, Flannel and Etcd are no longer baked into the host's image, but are installable instead either as [system containers](http://www.projectatomic.io/blog/2016/09/intro-to-system-containers/) or via [package layering](https://rpm-ostree.readthedocs.io/en/latest/manual/administrator-handbook/#hybrid-imagepackaging-via-package-layering).
 
 System containers can serve as drop-in replacements for components that had been included in the Fedora Atomic image. Once installed, these components will be manageable using the same systemctl commands that apply to regular rpm-installed components. System containers are very flexible -- you can easily run system container images based on CentOS or on older (or newer) versions of Fedora on a Fedora Atomic 27 host.
 
-Package layering makes it possible to install regular rpm packages from configured repositories. These additional "layered" packages are persistent across upgrades, rebases, and deploys. You must typically reboot after layering on packages, and not all packages may be installed in this way. For instance, rpms that install content to `/opt` aren't currently installable via package layering. Unlike with system containers, the packages you layer onto your host must be compatible with the version of Fedora the host is running.
+Package layering makes it possible to install regular rpm packages from configured repositories. These additional "layered" packages are persistent across upgrades, rebases, and deploys. You must typically reboot after layering on packages, and not all packages may be installed in this way. For instance, rpms that install content to `/opt` [aren't currently installable](https://github.com/projectatomic/rpm-ostree/issues/233) via package layering. Unlike with system containers, the packages you layer onto your host must be compatible with the version of Fedora the host is running.
 
-I've you're running a Kubernetes cluster on Fedora Atomic Host that depends on the baked in versions of these components, such as a cluster installed via the Ansible scripts in the [kubernetes/contrib repo](https://github.com/kubernetes/contrib/tree/master/ansible), you'll need to choose one of these methods to migrate your cluster when [upgrading to Fedora Atomic 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/).
+If you're running a Kubernetes cluster on Fedora Atomic Host that depends on the baked in versions of these components, such as a cluster installed via the Ansible scripts in the [kubernetes/contrib repo](https://github.com/kubernetes/contrib/tree/master/ansible), you'll need to choose one of these methods to migrate your cluster when [upgrading to Fedora Atomic 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/).
 
 ## Migrating Kubernetes and related components using System Containers
 
-To replace Kubernetes, Flannel and Etcd with system containers, you would run the following commands. You could run these commands on a Fedora Atomic 26 host, [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/), and, upon rebooting, your components and any cluster based on them should be up and running. 
+To replace Kubernetes, Flannel and Etcd with system containers, you would run the following commands. You could run these commands on a Fedora 26 Atomic Host, and then [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/). Upon rebooting, your components and any cluster based on them should be up and running. 
 
 ### System containers for master nodes
 
@@ -46,7 +46,7 @@ Note: the kube-apiserver system container provides the `kubectl` client.
 # atomic install --system --system-package=no --storage=ostree --name etcd registry.fedoraproject.org/f27/etcd
 ```
 
-When installed with the name "etcd," the etcd system container expects to find stores etcd data in `/var/lib/etcd/etcd.etcd`. The etcd rpm is configured by default to store data in `/var/lib/etcd/default.etcd`, and the ansible scripts in [kubernetes/contrib](https://github.com/kubernetes/contrib/tree/master/ansible) use `/var/lib/etcd`. On a system running etcd as configured by the kubernetes/contrib ansible scripts, you'd move your data as follows:
+When installed with the name **etcd**, the etcd system container expects to find stores etcd data in `/var/lib/etcd/etcd.etcd`. The etcd rpm is configured by default to store data in `/var/lib/etcd/default.etcd`, and the ansible scripts in [kubernetes/contrib](https://github.com/kubernetes/contrib/tree/master/ansible) use `/var/lib/etcd`. On a system running etcd as configured by the kubernetes/contrib ansible scripts, you'd move your data as follows:
 
 ```bash
 # systemctl stop etcd

--- a/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
+++ b/source/blog/2017-11-15-migrating-kubernetes-on-fedora-atomic-host-27.html.md
@@ -77,7 +77,7 @@ System container updates are independent of host updates. You can update a syste
  # atomic containers rollback etcd
  ```
 
-## Migrating Kubernetes and related components using Package Layering
+## Migrating Kubernetes and related components using RPM Package Layering
 
 During the [upgrade to 27](http://www.projectatomic.io/blog/2017/11/fedora-atomic-26-to-27-upgrade/), you can opt to layer on particular packages by appending `--install PACKAGE` to the `rpm-ostree rebase` commands. Upon rebooting into 27, your components and any cluster based on them should be up and running. 
 


### PR DESCRIPTION
I have TK's in here for a link to the main upgrading f27 atomic post, and we need to get the system containers referenced in here built/released.