### PR TITLE
Use the new url for the tracker

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -188,7 +188,7 @@ require 'lib/monkeypatch_blog_date.rb'
 
 activate :piwik do |f|
     f.id = 4
-    f.domain = 'piwik-osasteam.rhcloud.com'
+    f.domain = 'tracker.osci.io'
     f.url = 'piwik'
 end
 


### PR DESCRIPTION
Since we are moving it out of openshift, we need to use another name