### PR TITLE
Do not hardcode http in url for image

### DIFF
--- a/source/blog/2018-01-26-using-image-registries-with-buildah.md
+++ b/source/blog/2018-01-26-using-image-registries-with-buildah.md
@@ -8,7 +8,7 @@ comments: false
 tags: buildah, oci, containers, registry
 ---
 
-![Buildah](http://www.projectatomic.io/images/buildah-logo.png?1517062481)
+![Buildah](/images/buildah-logo.png?1517062481)
 
 # Using Buildah with container registries
 


### PR DESCRIPTION
Firefox show a warning regarding insecure content, since the blog post is
on the frontpage.