### PR TITLE
blog: update kernel arguments on Atomic Host

### DIFF
--- a/data/authors.yml
+++ b/data/authors.yml
@@ -174,3 +174,6 @@ sayan:
 
 sinnykumari:
   name: Sinny Kumari
+
+rubao:
+  name: Ruixin Bao

--- a/source/blog/2018-03-06-update-kernel-arguments-on-atomic-host.html.md
+++ b/source/blog/2018-03-06-update-kernel-arguments-on-atomic-host.html.md
@@ -1,0 +1,186 @@
+---
+title: Update Kernel arguments on Atomic Host
+author: rubao
+date: 2018-03-06 17:00:00 UTC
+published: true
+comments: false
+tags:
+- atomic
+- rpm-ostree
+---
+
+Users or adminstrators may want to change [kernel arguments](https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html) of Atomic Host for various reasons.
+Before, it seemed hard for the users to do so due to many of
+the steps involved, and the harmful consequeces that can occur if users accidentally
+make a mistake in the changing process.
+
+In this post, I want to introduce a command(rpm-ostree ex kargs) that
+allows users to change kernel arguments on Atomic Host. This command simplifies
+the process of changing kernel arguments into few simple commands. This command also
+currently lies beneath [rpm-ostree](https://github.com/projectatomic/rpm-ostree),
+and because of that, it benefits from many of the cool features from rpm-ostree.
+One of them is `rpm-ostree rollback`, which can allow users to undo their old changes
+they do not want.
+
+Note: This command is still under experimentation, so if you have seen any
+unexpected behavior happening, please report an issue to rpm-ostree. This
+post also might be a bit difficult to understand without prior knowledge to
+rpm-ostree and Atomic Host, please bear that in mind when reading this.
+
+
+READMORE
+
+Let's demonstrate some of the options that can be done with this command!
+
+# Display the current kernel arguments
+
+The rpm-ostree ex kargs command can allow users to see the kernel arguments
+from different locations, including the current kernel arguments, arguments
+from /proc/cmdline as well as kernel arguments from a specific deployment
+
+
+The command following will show the kernel arguments from first bootable entry
+in your grub.cfg:
+```
+[root@localhost ~]# rpm-ostree ex kargs
+The kernel arguments are:
+no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+```
+
+This command will show you the kernel arguments from the first deployment
+```
+[root@localhost ~]# rpm-ostree ex kargs --deploy-index=0
+The kernel arguments are:
+no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+```
+
+This will show you the current kernel arguments being used in /proc/cmdline
+```
+[root@localhost ~]# rpm-ostree ex kargs  --import-proc-cmdline
+The kernel arguments are:
+no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+
+```
+
+# Changing the kernel arguments
+
+Similarly, you can fetch kernel arguments from three different locations mentioned above,
+but for readability and simplicty, we are only demoing with the first one(first
+bootable entry) here.
+
+You have four different options of changing kernel arguments in the command, all of those
+will create a deployment, meaning its changes can be revertable. A more detailed description
+will be shown by `rpm-ostree ex kargs --help`
+
+## 1: Add one or multiple kernel arguments to the list
+
+The user can append the argument using append option, and the format for the value
+pair will be in terms of key=value. The changes are rollbackable as mentioned earlier.
+
+```
+[root@localhost ~]# rpm-ostree ex kargs --append=test_add=test
+Copying /etc changes: 21 modified, 0 removed, 87 added
+Transaction complete; bootconfig swap: yes deployment count change: 0
+Kernel arguments updated.
+Run "systemctl reboot" to start a reboot
+```
+
+Now we want to verify if the changes got added to the grub.cfg, because
+that is what is going to be used when user boots into the system
+
+```
+[root@localhost ~]# cat /boot/grub2/grub.cfg | grep test_add=test
+linux16 /ostree/fedora-atomic-9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/vmlinuz-4.14.13-300.fc27.x86_64 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.1/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0 test_add=test
+linux16 /ostree/fedora-atomic-9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/vmlinuz-4.14.13-300.fc27.x86_64 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.1/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0 test_add=test ds=nocloud\;h=localhost\;i=devmode\;s=/usr/share/atomic-devmode/cloud-init.
+```
+
+Now we want to show that changes are rollbackable
+```
+[root@localhost ~]# systemctl reboot
+Connection to 192.168.121.188 closed by remote host.
+Connection to 192.168.121.188 closed.
+
+[root@localhost ~]# rpm-ostree rollback
+Moving '772ab185b0752b0d6bc8b2096d08955660d80ed95579e13e136e6a54e3559ca9.0' to be first deployment
+Transaction complete; bootconfig swap: yes deployment count change: 0
+Run "systemctl reboot" to start a reboot
+[root@localhost ~]# rpm-ostree ex kargs
+The kernel arguments are:
+no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+
+```
+
+## 2: Replace one or multiple arguments
+
+To replace the value, the input will be in the form of key=oldvalue=newvalue, or when there
+is only one single key value pair, you can replace it by key=newvalue. Note, to avoid duplication,
+we skip the process of changing the actual grub.cfg here.
+
+```
+[root@localhost ~]# rpm-ostree ex kargs --replace no_timer_check=""=test_val --replace net.ifnames=0=new_val
+Copying /etc changes: 21 modified, 0 removed, 92 added
+Transaction complete; bootconfig swap: yes deployment count change: 0
+Kernel arguments updated.
+Run "systemctl reboot" to start a reboot
+[root@localhost ~]# rpm-ostree ex kargs
+The kernel arguments are:
+no_timer_check=test_val console=tty1 console=ttyS0,115200n8 net.ifnames=new_val biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.1/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+
+[root@localhost ~]# rpm-ostree ex kargs --replace no_timer_check="" --replace net.ifnames=0
+Copying /etc changes: 21 modified, 0 removed, 92 added
+Transaction complete; bootconfig swap: yes deployment count change: 0
+Kernel arguments updated.
+Run "systemctl reboot" to start a reboot
+[root@localhost ~]# rpm-ostree ex kargs
+The kernel arguments are:
+no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+```
+
+## 3: Delete one or multiple arguments
+
+To delete one or more kernel arguments, the input will be in the form of key=value format. Similarly, when
+there is only one single key=value pair, we allow users to delete argument by key name.
+
+```
+[root@localhost ~]# rpm-ostree ex kargs --delete no_timer_check --delete console=tty1
+Copying /etc changes: 21 modified, 0 removed, 92 added
+Transaction complete; bootconfig swap: yes deployment count change: 0
+Kernel arguments updated.
+Run "systemctl reboot" to start a reboot
+[root@localhost ~]# rpm-ostree ex kargs
+The kernel arguments are:
+console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.1/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+
+```
+
+## 4: Allow user to do all above actions using an editor
+
+Note: the kernel arguments were from the previous section, and the example below will show
+you the already changed ones because it is hard to demo from a separate editor side.
+
+```
+[root@localhost ~]# rpm-ostree ex kargs --editor
+
+======================================EDITOR SCREEN=================================================
+# Please enter the kernel arguments. Each kernel argument# should be in the form of key=value.
+# Lines starting with '#' will be ignored. Each key=value pair should be
+# separated by spaces, and multiple value associated with one key is allowed.
+# Also, please note that any changes to the ostree argument will not be
+# effective as they are usually regenerated when bootconfig changes.
+test=test console=ttyS0,115200n8 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root
+=====================================END OF EDITOR SCREEN===========================================
+Copying /etc changes: 21 modified, 0 removed, 92 added
+Transaction complete; bootconfig swap: yes deployment count change: 0
+Kernel arguments updated.
+Run "systemctl reboot" to start a reboot
+
+[root@localhost ~]# rpm-ostree ex kargs
+The kernel arguments are:
+test=test console=ttyS0,115200n8 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
+```
+
+# More information:
+- [Upstream pull request](https://github.com/projectatomic/rpm-ostree/pull/1013)
+- [Original proposal](https://github.com/projectatomic/rpm-ostree/issues/594)
+```
+

--- a/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
+++ b/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
@@ -11,10 +11,10 @@ tags:
 
 Users or adminstrators may want to change [kernel arguments](https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html) of Atomic Host for various reasons.
 Previously, it was hard for the users due to many of the steps involved,
-and the harmful consequeces that can occur if users accidentally make a mistake
+and the harmful consequences that can occur if users accidentally make a mistake
 in the changing process.
 
-In this post, I want to introduce a command(`rpm-ostree ex kargs`) that
+In this post, I want to introduce a command (`rpm-ostree ex kargs`) that
 allows users to change kernel arguments on Atomic Host. This command simplifies
 the process of changing kernel arguments. This command also lies
 beneath [rpm-ostree](https://github.com/projectatomic/rpm-ostree),
@@ -23,7 +23,8 @@ One of them is `rpm-ostree rollback`, which can allow users to undo their old ch
 they do not want.
 
 Note: This command is still experimental, so if you have seen any
-unexpected behavior happening, please report an issue to rpm-ostree. This
+unexpected behavior happening, please report an issue to
+[rpm-ostree](https://github.com/projectatomic/rpm-ostree/issues/new). This
 post also requires some knowledge of Atomic Host and rpm-ostree, please
 bear that in mind when reading this.
 
@@ -70,7 +71,7 @@ but for readability and simplicty, we are only demoing with the first one (first
 bootable entry) here.
 
 You have four different options of changing kernel arguments in the command. All of those
-creates a deployment, and can be revertible through `rpm-ostree rollback`. A more
+creates a deployment, and can be reverted through `rpm-ostree rollback`. A more
 detailed description of the commands can be shown by `rpm-ostree ex kargs --help`
 
 ## 1: Add one or multiple kernel arguments to the list

--- a/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
+++ b/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
@@ -1,7 +1,7 @@
 ---
 title: Update Kernel arguments on Atomic Host
 author: rubao
-date: 2018-03-08 17:00:00 UTC
+date: 2018-03-08 00:00:00 UTC
 published: true
 comments: false
 tags:

--- a/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
+++ b/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
@@ -27,18 +27,18 @@ unexpected behavior happening, please report an issue to rpm-ostree. This
 post also requires some knowledge of Atomic Host and rpm-ostree, please
 bear that in mind when reading this.
 
-READMORE
-
 Let's demonstrate some of the options that can be done with this command!
+
+READMORE
 
 # Display the current kernel arguments
 
 The `rpm-ostree ex kargs` command can allow users to see the kernel arguments
 from different locations, including the current kernel arguments, arguments
-from /proc/cmdline as well as kernel arguments from a specific deployment.
+from `/proc/cmdline` as well as kernel arguments from a specific deployment.
 
 
-The command following will show the kernel arguments from first bootable entry
+The command following shows the kernel arguments from first bootable entry
 in your grub.cfg:
 
 ```
@@ -47,7 +47,7 @@ The kernel arguments are:
 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
 ```
 
-This command will show you the kernel arguments from the first deployment:
+This command shows you the kernel arguments from the first deployment:
 
 ```
 [root@localhost ~]# rpm-ostree ex kargs --deploy-index=0
@@ -55,7 +55,8 @@ The kernel arguments are:
 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
 ```
 
-This will show you the current kernel arguments being used in /proc/cmdline:
+This shows you the current kernel arguments being used in `/proc/cmdline`:
+
 ```
 [root@localhost ~]# rpm-ostree ex kargs  --import-proc-cmdline
 The kernel arguments are:
@@ -69,13 +70,13 @@ but for readability and simplicty, we are only demoing with the first one (first
 bootable entry) here.
 
 You have four different options of changing kernel arguments in the command. All of those
-will create a deployment, and can be revertible through `rpm-ostree rollback`. A more
-detailed description of the commands will be shown by `rpm-ostree ex kargs --help`
+creates a deployment, and can be revertible through `rpm-ostree rollback`. A more
+detailed description of the commands can be shown by `rpm-ostree ex kargs --help`
 
 ## 1: Add one or multiple kernel arguments to the list
 
 The user can append the argument using append option, and the format for the value
-pair will be in terms of key=value. The changes can be rolled back as mentioned earlier.
+pair is in terms of key=value. The changes can be rolled back as mentioned earlier.
 
 ```
 [root@localhost ~]# rpm-ostree ex kargs --append=test_add=test
@@ -95,6 +96,7 @@ linux16 /ostree/fedora-atomic-9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e29
 ```
 
 Now we want to show that changes can be rolled back:
+
 ```
 [root@localhost ~]# systemctl reboot
 Connection to 192.168.121.188 closed by remote host.
@@ -111,9 +113,9 @@ no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 r
 
 ## 2: Replace one or multiple arguments
 
-To replace the value, the input will be in the form of key=oldvalue=newvalue, or when there
+To replace the value, the input is in the form of key=oldvalue=newvalue, or when there
 is only one single key value pair, you can replace it by key=newvalue. Note, to avoid duplication,
-we skip modifying grub.cfg here.
+we skip showing the modified grub.cfg here.
 
 ```
 [root@localhost ~]# rpm-ostree ex kargs --replace no_timer_check=""=test_val --replace net.ifnames=0=new_val
@@ -137,7 +139,7 @@ no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 r
 
 ## 3: Delete one or multiple arguments
 
-To delete one or more kernel arguments, the input will be in the form of key=value format. Similarly, when
+To delete one or more kernel arguments, the input is in the form of key=value format. Similarly, when
 there is only one single key=value pair, we allow users to delete argument by key name.
 
 ```
@@ -179,9 +181,9 @@ test=test console=ttyS0,115200n8 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev
 
 # Conclusion:
 
-Those are all the major functionalities for `rpm-ostree ex kargs`. Feel free to try this out, feedbacks are always welcome!
-To post feedback about this command, you can post a issue on [rpm-ostree repo](https://github.com/projectatomic/rpm-ostree/issues),
-or join #atomic on freenode to ask questions. Thank you for reading this document!
+This covers all the major functionalities for `rpm-ostree ex kargs`. Feel free to try this out, feedback is always welcome!
+To post feedback about this command, you can post an issue on [rpm-ostree repo](https://github.com/projectatomic/rpm-ostree/issues),
+or join #atomic on freenode to ask questions. Thanks for reading!
 
 # More information:
 - [Upstream pull request](https://github.com/projectatomic/rpm-ostree/pull/1013)

--- a/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
+++ b/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
@@ -1,7 +1,7 @@
 ---
 title: Update Kernel arguments on Atomic Host
 author: rubao
-date: 2018-03-06 17:00:00 UTC
+date: 2018-03-08 17:00:00 UTC
 published: true
 comments: false
 tags:
@@ -10,23 +10,22 @@ tags:
 ---
 
 Users or adminstrators may want to change [kernel arguments](https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html) of Atomic Host for various reasons.
-Before, it seemed hard for the users to do so due to many of
-the steps involved, and the harmful consequeces that can occur if users accidentally
-make a mistake in the changing process.
+Previously, it was hard for the users due to many of the steps involved,
+and the harmful consequeces that can occur if users accidentally make a mistake
+in the changing process.
 
-In this post, I want to introduce a command(rpm-ostree ex kargs) that
+In this post, I want to introduce a command(`rpm-ostree ex kargs`) that
 allows users to change kernel arguments on Atomic Host. This command simplifies
-the process of changing kernel arguments into few simple commands. This command also
-currently lies beneath [rpm-ostree](https://github.com/projectatomic/rpm-ostree),
+the process of changing kernel arguments. This command also lies
+beneath [rpm-ostree](https://github.com/projectatomic/rpm-ostree),
 and because of that, it benefits from many of the cool features from rpm-ostree.
 One of them is `rpm-ostree rollback`, which can allow users to undo their old changes
 they do not want.
 
-Note: This command is still under experimentation, so if you have seen any
+Note: This command is still experimental, so if you have seen any
 unexpected behavior happening, please report an issue to rpm-ostree. This
-post also might be a bit difficult to understand without prior knowledge to
-rpm-ostree and Atomic Host, please bear that in mind when reading this.
-
+post also requires some knowledge of Atomic Host and rpm-ostree, please
+bear that in mind when reading this.
 
 READMORE
 
@@ -34,48 +33,49 @@ Let's demonstrate some of the options that can be done with this command!
 
 # Display the current kernel arguments
 
-The rpm-ostree ex kargs command can allow users to see the kernel arguments
+The `rpm-ostree ex kargs` command can allow users to see the kernel arguments
 from different locations, including the current kernel arguments, arguments
-from /proc/cmdline as well as kernel arguments from a specific deployment
+from /proc/cmdline as well as kernel arguments from a specific deployment.
 
 
 The command following will show the kernel arguments from first bootable entry
 in your grub.cfg:
+
 ```
 [root@localhost ~]# rpm-ostree ex kargs
 The kernel arguments are:
 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
 ```
 
-This command will show you the kernel arguments from the first deployment
+This command will show you the kernel arguments from the first deployment:
+
 ```
 [root@localhost ~]# rpm-ostree ex kargs --deploy-index=0
 The kernel arguments are:
 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
 ```
 
-This will show you the current kernel arguments being used in /proc/cmdline
+This will show you the current kernel arguments being used in /proc/cmdline:
 ```
 [root@localhost ~]# rpm-ostree ex kargs  --import-proc-cmdline
 The kernel arguments are:
 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
-
 ```
 
 # Changing the kernel arguments
 
 Similarly, you can fetch kernel arguments from three different locations mentioned above,
-but for readability and simplicty, we are only demoing with the first one(first
+but for readability and simplicty, we are only demoing with the first one (first
 bootable entry) here.
 
-You have four different options of changing kernel arguments in the command, all of those
-will create a deployment, meaning its changes can be revertable. A more detailed description
-will be shown by `rpm-ostree ex kargs --help`
+You have four different options of changing kernel arguments in the command. All of those
+will create a deployment, and can be revertible through `rpm-ostree rollback`. A more
+detailed description of the commands will be shown by `rpm-ostree ex kargs --help`
 
 ## 1: Add one or multiple kernel arguments to the list
 
 The user can append the argument using append option, and the format for the value
-pair will be in terms of key=value. The changes are rollbackable as mentioned earlier.
+pair will be in terms of key=value. The changes can be rolled back as mentioned earlier.
 
 ```
 [root@localhost ~]# rpm-ostree ex kargs --append=test_add=test
@@ -86,7 +86,7 @@ Run "systemctl reboot" to start a reboot
 ```
 
 Now we want to verify if the changes got added to the grub.cfg, because
-that is what is going to be used when user boots into the system
+that is what is going to be used when user boots into the system.
 
 ```
 [root@localhost ~]# cat /boot/grub2/grub.cfg | grep test_add=test
@@ -94,7 +94,7 @@ linux16 /ostree/fedora-atomic-9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e29
 linux16 /ostree/fedora-atomic-9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/vmlinuz-4.14.13-300.fc27.x86_64 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.1/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0 test_add=test ds=nocloud\;h=localhost\;i=devmode\;s=/usr/share/atomic-devmode/cloud-init.
 ```
 
-Now we want to show that changes are rollbackable
+Now we want to show that changes can be rolled back:
 ```
 [root@localhost ~]# systemctl reboot
 Connection to 192.168.121.188 closed by remote host.
@@ -107,14 +107,13 @@ Run "systemctl reboot" to start a reboot
 [root@localhost ~]# rpm-ostree ex kargs
 The kernel arguments are:
 no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
-
 ```
 
 ## 2: Replace one or multiple arguments
 
 To replace the value, the input will be in the form of key=oldvalue=newvalue, or when there
 is only one single key value pair, you can replace it by key=newvalue. Note, to avoid duplication,
-we skip the process of changing the actual grub.cfg here.
+we skip modifying grub.cfg here.
 
 ```
 [root@localhost ~]# rpm-ostree ex kargs --replace no_timer_check=""=test_val --replace net.ifnames=0=new_val
@@ -150,7 +149,6 @@ Run "systemctl reboot" to start a reboot
 [root@localhost ~]# rpm-ostree ex kargs
 The kernel arguments are:
 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.1/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
-
 ```
 
 ## 4: Allow user to do all above actions using an editor
@@ -179,8 +177,14 @@ The kernel arguments are:
 test=test console=ttyS0,115200n8 biosdevname=0 rd.lvm.lv=atomicos/root root=/dev/mapper/atomicos-root ostree=/ostree/boot.0/fedora-atomic/9a9b350be75846811cbb0b1fd7b3d42a49908ed1265bc59e292bb4a34674332c/0
 ```
 
+# Conclusion:
+
+Those are all the major functionalities for `rpm-ostree ex kargs`. Feel free to try this out, feedbacks are always welcome!
+To post feedback about this command, you can post a issue on [rpm-ostree repo](https://github.com/projectatomic/rpm-ostree/issues),
+or join #atomic on freenode to ask questions. Thank you for reading this document!
+
 # More information:
 - [Upstream pull request](https://github.com/projectatomic/rpm-ostree/pull/1013)
 - [Original proposal](https://github.com/projectatomic/rpm-ostree/issues/594)
-```
+- [rpm-ostree repo](https://github.com/projectatomic/rpm-ostree/)
 

--- a/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
+++ b/source/blog/2018-03-08-update-kernel-arguments-on-atomic-host.html.md
@@ -189,4 +189,4 @@ or join #atomic on freenode to ask questions. Thanks for reading!
 - [Upstream pull request](https://github.com/projectatomic/rpm-ostree/pull/1013)
 - [Original proposal](https://github.com/projectatomic/rpm-ostree/issues/594)
 - [rpm-ostree repo](https://github.com/projectatomic/rpm-ostree/)
-
+- [rpm-ostree doc](https://rpm-ostree.readthedocs.io/en/latest/)


### PR DESCRIPTION
This is my first attempt to try to submit a blog post to atomic site. So If there is anything I did wrong/horribly wrong(hopefully not the latter), feel free to point it out :). 

The blog was to introduce the `rpm-ostree ex kargs` command that was introduced a while ago. We discussed a bit about this in a standup, and it seemed to be a good option of having a blog post for ppl to test it out and give feedbacks.

That's why I am here :p. Comments are welcome and thanks in advance!
  