### PR TITLE
Add blog for Fedora 28 Atomic/Cloud Test Day

### DIFF
--- a/source/blog/2018-04-09-test-day-for-fedora-28-atomic-cloud-april-11th.html.md
+++ b/source/blog/2018-04-09-test-day-for-fedora-28-atomic-cloud-april-11th.html.md
@@ -1,0 +1,20 @@
+---
+title: Test Day for Fedora 28 Atomic/Cloud April 11th
+author: sinnykumari
+date: 2018-04-06
+comments: true
+published: true
+tags: atomic, fedora, test_day, cloud
+---
+
+With the Fedora 28 Beta [official release announcement](https://fedoramagazine.org/announcing-fedora-28-beta/), the [Fedora Atomic Working Group](https://fedoraproject.org/wiki/Atomic_WG) and [Fedora Cloud SIG](https://fedoraproject.org/wiki/Cloud_SIG) would like to invite members of the community to join us in finding and squashing bugs. We are organizing a Test Day on Wednesday, April 11th 2018.
+
+In this Test Day, you can test Fedora Atomic Host, Fedora Atomic Workstation and Fedora Cloud Base content. See the [Fedora Atomic Host Pre-Release Page](https://getfedora.org/en/atomic/prerelease/) for links to the artifacts for Fedora Atomic Host, [here](https://download.fedoraproject.org/pub/fedora/linux/releases/test/28_Beta/AtomicWorkstation/x86_64/iso/Fedora-AtomicWorkstation-ostree-x86_64-28_Beta-1.3.iso) for Atomic Workstation ISO link and the [Alternative Downloads Beta Page](https://alt.fedoraproject.org/prerelease/index.html) for links to Cloud Base Beta images. We have qcow, AMI and ISO images ready for testing.  Additionally, Vagrant Boxes will be available for testing as well.
+
+## How do test days work?
+
+A test day is an event where anyone can help make sure that changes in Fedora are working well in the upcoming release. Fedora community members often participate, but the public is welcome also. You only need to be able to download materials (including some large files), and read and follow technical directions step by step, to contribute.
+
+Need some help on what to test and how to test? Checkout [wiki page](https://fedoraproject.org/wiki/Test_Day:2018-04-11_Cloud-Atomic_Testday) page which provides detailed information about the Atomic/Cloud test day. If you’re available on or around the day of the event, please do some testing . Once you’ve done the testing, make sure to log your test results in the [test day web application](http://testdays.fedorainfracloud.org/events/39).
+
+Happy testing, and we hope to see you on test day!

--- a/source/blog/2018-04-09-test-day-for-fedora-28-atomic-cloud-april-11th.html.md
+++ b/source/blog/2018-04-09-test-day-for-fedora-28-atomic-cloud-april-11th.html.md
@@ -1,13 +1,15 @@
 ---
 title: Test Day for Fedora 28 Atomic/Cloud April 11th
 author: sinnykumari
-date: 2018-04-06
-comments: true
+date: 2018-04-09
+comments: false
 published: true
 tags: atomic, fedora, test_day, cloud
 ---
 
 With the Fedora 28 Beta [official release announcement](https://fedoramagazine.org/announcing-fedora-28-beta/), the [Fedora Atomic Working Group](https://fedoraproject.org/wiki/Atomic_WG) and [Fedora Cloud SIG](https://fedoraproject.org/wiki/Cloud_SIG) would like to invite members of the community to join us in finding and squashing bugs. We are organizing a Test Day on Wednesday, April 11th 2018.
+
+READMORE
 
 In this Test Day, you can test Fedora Atomic Host, Fedora Atomic Workstation and Fedora Cloud Base content. See the [Fedora Atomic Host Pre-Release Page](https://getfedora.org/en/atomic/prerelease/) for links to the artifacts for Fedora Atomic Host, [here](https://download.fedoraproject.org/pub/fedora/linux/releases/test/28_Beta/AtomicWorkstation/x86_64/iso/Fedora-AtomicWorkstation-ostree-x86_64-28_Beta-1.3.iso) for Atomic Workstation ISO link and the [Alternative Downloads Beta Page](https://alt.fedoraproject.org/prerelease/index.html) for links to Cloud Base Beta images. We have qcow, AMI and ISO images ready for testing.  Additionally, Vagrant Boxes will be available for testing as well.
 


### PR DESCRIPTION
Link for test page wiki and test cases are not yet available. Will update this PR with those links once they are available.