### PR TITLE
Refer to Team Silverblue

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -13,7 +13,7 @@ blog_summary_length: 500
     Deploy and Manage Your Containers in the Next-Generation Container OS
   %p.lead
 
-    Use immutable infrastructure to deploy and scale your containerized applications. Project Atomic mainly comprises Atomic Host, Atomic Workstation, and various container tooling.
+    Use immutable infrastructure to deploy and scale your containerized applications. Project Atomic mainly comprises Atomic Host, Team Silverblue, and various container tooling.
     cloud native platforms.
 
   = partial "social"
@@ -46,12 +46,14 @@ blog_summary_length: 500
 
       .col-xs-12.col-lg-4
 
-        %h2 Atomic Workstation
+        %h2 Team Silverblue
 
         %p
-          %b Fedora Atomic Workstation (FAW)
+          %b Team Silverblue
           provides immutable infrastructure for your desktop experience.
-
+          %a( href="https://teamsilverblue.org" )
+            %i.fa.fa-fw.fa-graduation-cap
+            Team Silverblue
 
   .col-md-12
     .row


### PR DESCRIPTION
Refer to Team Silverblue instead of Fedora Atomic Workstation,
and link to www.teamsilverblue.org.