### PR TITLE
remove links to unsupported documentation

### DIFF
--- a/data/docs.yml
+++ b/data/docs.yml
@@ -2,7 +2,6 @@
 - First Steps:
   Introduction: /docs/introduction
   Quick Start Guide: /docs/quickstart
-  Getting Started Guide: /docs/gettingstarted
   Bare Metal Installation (Fedora): /docs/fedora_atomic_bare_metal_installation
 - In Depth:
   rpm-ostree OS Update System: /docs/os-updates
@@ -11,7 +10,6 @@
   Building Images: /docs/docker-building-images
   Image Author Guidance: /docs/docker-image-author-guidance
   About SELinux: /docs/docker-and-selinux
-  Managing Containers: /docs/kubernetes
   Atomic Host Networking: /docs/atomic-host-networking
 - Contributing:
   How to Contribute: /docs/#contribute

--- a/source/docs/index.html.haml
+++ b/source/docs/index.html.haml
@@ -19,7 +19,7 @@ title: Project Atomic Documentation
   <a href="/docs/quickstart/">Quick Start Guide</a>.
   will help you get Atomic up and running quickly.
 
-%p
+-#%p
 
   When Atomic is up and running, read the
   %a( href="/docs/gettingstarted/" ) Getting Started Guide

--- a/source/docs/quickstart.md
+++ b/source/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Project Atomic Quick Start Guide
 
-We recommend reading the [Getting Started Guide](http://www.projectatomic.io/docs/gettingstarted) and Concepts Guide if you're entirely new to the concept of Atomic and Docker. But, we also wanted to provide a **Quick Start Guide** (or "guide for the impatient") for folks who just want to set up a single Atomic host and see what all the fuss around Docker and Atomic is about.
+This a **Quick Start Guide** (or "guide for the impatient") for folks who just want to set up a single Atomic Host and see what all the fuss around Docker and Atomic is about.
 
 ## What You Need
 
@@ -23,7 +23,7 @@ There are three basic steps we'll do for each virtualization provider before boo
 
 ## Prep the cloud-init source ISO
 
-In order to pass run time customizations to an Atomic host, we use [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) .  
+In order to pass run time customizations to an Atomic host, we use [**cloud-init**](http://cloudinit.readthedocs.org/en/latest/) .
 
 You will need to create a metadata ISO to supply critical data when your Atomic host boots.  System data is presented via the `meta-data` file and configuration data via the `user-data` file.  We will be setting up the password and ssh key for the default user.  The metatdata ISO is created on the machine running your virtualization provider.
 

--- a/source/download/index.html.haml
+++ b/source/download/index.html.haml
@@ -49,7 +49,7 @@ The <a href="https://fedoraproject.org/wiki/Cloud_SIG">Fedora Cloud SIG</a> offe
       to create a new virtual machine with Atomic and set
       up more disk space for your containers.  This guide will set up a single host capable of running Docker containers.
 
-    %h2 Configure an Atomic cluster
+-#    %h2 Configure an Atomic cluster
 
     %p
       Atomic hosts are either used in a standalone configuration to run Docker containers or in an orchestrated cluster to run Kubernetes pods.


### PR DESCRIPTION
The Getting Started Guide for setting up an Atomic Cluster and the
docs around Kubernetes are old, unmaintained, and hard to provide
support for.

Let's stop pointing users at these docs and try to find a better way
for users to experiment with kubernetes, etc.

This is not an exhaustive removal of the links to both guides, but the
primary entrypoints that I found.