### PR TITLE
Modified Team Silverblue URL

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -51,7 +51,7 @@ blog_summary_length: 500
         %p
           %b Team Silverblue
           provides immutable infrastructure for your desktop experience.
-          %a( href="https://teamsilverblue.org" )
+          %a( href="https://silverblue.fedoraproject.org" )
             %i.fa.fa-fw.fa-graduation-cap
             Team Silverblue
 


### PR DESCRIPTION
The canonical URL for the Silverblue project appears to be https://silverblue.fedoraproject.org, not https://teamsilverblue.org/. While https://teamsilverblue.org/ looks to have redirected to the proper site in the past it currently does not. Also, the ownership of teamsilverblue.org is unclear (to me) but judging by the IP and name server it does not seem to be an official Fedora Project domain.