### PR TITLE
docs: update link to upstream kubernetes ansible

### DIFF
--- a/source/docs/kubernetes.md
+++ b/source/docs/kubernetes.md
@@ -14,7 +14,7 @@ Fedora's Kubernetes [is packaged](https://apps.fedoraproject.org/packages/kubern
 
 ### Deployment
 
-The simplest and most complete way to bring up a Kubernetes cluster with Fedora Atomic Host is to use the upstream [kubernetes ansible scripts](https://github.com/kubernetes/contrib/tree/master/ansible). For a more manual approach, consult the [getting started guide](http://www.projectatomic.io/docs/gettingstarted/).
+The simplest and most complete way to bring up a Kubernetes cluster with Fedora Atomic Host is to use the upstream [kubernetes ansible scripts](https://github.com/kubernetes-incubator/kubespray). For a more manual approach, consult the [getting started guide](http://www.projectatomic.io/docs/gettingstarted/).
 
 Up until late 2016, Fedora's kubernetes packages were based on a version of kubernetes adapted from openshift origin, which itself was adapted from upstream kubernetes. This arrangement led to delays between upstream kubernetes releases and Fedora's kubernetes releases. Currently, Fedora's kubernetes is based directly on upstream, which has enabled Fedora to significantly narrow the release gap.
 


### PR DESCRIPTION
The current link repository has a [README](https://github.com/kubernetes/contrib/blame/master/ansible/README.md#L3) with this message:

> **DEPRECATED**: See repo https://github.com/kubernetes-incubator/kubespray

This pull request updates the link to the new repository.