### PR TITLE
Add a note about the system container install of etcd

### DIFF
--- a/source/docs/gettingstarted.md
+++ b/source/docs/gettingstarted.md
@@ -81,6 +81,8 @@ We first install the etcd package:
 
     [fedora@atomic-master ~]$ sudo rpm-ostree install etcd
 
+**Note:** If you have installed etcd [as a system container](https://www.projectatomic.io/blog/2017/11/migrating-kubernetes-on-fedora-atomic-host-27/), do not perform this step.
+
 Then edit the configuration file:
 
     [fedora@atomic-master ~]$ sudo vi /etc/etcd/etcd.conf


### PR DESCRIPTION
I been walking through this guide today finding some areas where updates are needed.

Add a note pertaining to the installation of `etcd`. The rpm-ostree command should not be used if etcd has been installed already as a system container.