### PR TITLE
option error in '/etc/kubernetes/config'

### DIFF
--- a/source/docs/gettingstarted.md
+++ b/source/docs/gettingstarted.md
@@ -132,7 +132,7 @@ We'll be setting up the etcd store that Kubernetes will use.  We're using a sing
 
     [fedora@atomic-master ~]$ sudo vi /etc/kubernetes/config
     # Comma separated list of nodes in the etcd cluster
-    KUBE_ETCD_SERVERS="--etcd_servers=http://192.168.122.10:2379"
+    KUBE_ETCD_SERVERS="--etcd-servers=http://192.168.122.10:2379"
 
     # How the controller-manager, scheduler, and proxy find the kube-apiserver
     KUBE_MASTER="--master=http://192.168.122.10:8080"


### PR DESCRIPTION
I think I found a mistake in the Kubernetes setup docs:

"--etcd_servers=http://192.168.122.10:2379"  

unscore should be a hyphen,

"--etcd-servers=http://192.168.122.10:2379"